### PR TITLE
feat: Add Linux platform support

### DIFF
--- a/UnrealClaude/Source/UnrealClaude/Public/ClaudeCodeRunner.h
+++ b/UnrealClaude/Source/UnrealClaude/Public/ClaudeCodeRunner.h
@@ -6,9 +6,10 @@
 #include "IClaudeRunner.h"
 #include "HAL/Runnable.h"
 #include "HAL/RunnableThread.h"
+#include "HAL/PlatformProcess.h"
 
 /**
- * Async runner for Claude Code CLI commands (Windows implementation)
+ * Async runner for Claude Code CLI commands (cross-platform implementation)
  * Executes 'claude -p' in print mode and captures output
  * Implements IClaudeRunner interface for abstraction
  */
@@ -62,7 +63,6 @@ private:
 	/** Accumulated text from assistant messages for the final response */
 	FString AccumulatedResponseText;
 
-#if PLATFORM_WINDOWS
 	/** Create pipes for process stdout/stderr capture */
 	bool CreateProcessPipes();
 
@@ -77,7 +77,6 @@ private:
 
 	/** Report completion to callback on game thread */
 	void ReportCompletion(const FString& Output, bool bSuccess);
-#endif
 
 	FClaudeRequestConfig CurrentConfig;
 	FOnClaudeResponse OnCompleteDelegate;
@@ -87,15 +86,14 @@ private:
 	FThreadSafeCounter StopTaskCounter;
 	TAtomic<bool> bIsExecuting;
 
-	// Process handles for cancellation (Windows HANDLE stored as void*)
-	void* ProcessHandle;
+	// Process handle (FProcHandle stored as void* for atomic exchange compatibility)
+	FProcHandle ProcessHandle;
+
+	// Pipe handles (UE cross-platform pipe handles)
 	void* ReadPipe;
 	void* WritePipe;
 	void* StdInReadPipe;
 	void* StdInWritePipe;
-
-	// Last Windows error code for detailed error reporting
-	uint32 LastProcessError = 0;
 
 	// Temp file paths for prompts (to avoid command line length limits)
 	FString SystemPromptFilePath;

--- a/UnrealClaude/UnrealClaude.uplugin
+++ b/UnrealClaude/UnrealClaude.uplugin
@@ -3,7 +3,7 @@
 	"Version": 2,
 	"VersionName": "1.1.1",
 	"FriendlyName": "Unreal Claude",
-	"Description": "Claude Code CLI integration for Unreal Engine 5.7. Get AI coding assistance with built-in UE5.7 documentation context directly in the editor. Windows only.",
+	"Description": "Claude Code CLI integration for Unreal Engine 5.7. Get AI coding assistance with built-in UE5.7 documentation context directly in the editor.",
 	"Category": "Editor",
 	"CreatedBy": "Natali Caggiano",
 	"CreatedByURL": "https://github.com/Natfii",
@@ -16,13 +16,13 @@
 	"Installed": false,
 	"EnabledByDefault": true,
 	"EngineVersion": "5.7.0",
-	"SupportedTargetPlatforms": [ "Win64" ],
+	"SupportedTargetPlatforms": [ "Win64", "Linux" ],
 	"Modules": [
 		{
 			"Name": "UnrealClaude",
 			"Type": "Editor",
 			"LoadingPhase": "PostEngineInit",
-			"PlatformAllowList": [ "Win64" ]
+			"PlatformAllowList": [ "Win64", "Linux" ]
 		}
 	],
 	"Plugins": [


### PR DESCRIPTION
## Summary

This PR ports the UnrealClaude plugin from Windows-only to cross-platform (Windows + Linux) by replacing all raw Win32 API calls with Unreal Engine's built-in `FPlatformProcess` abstractions. Windows behavior is unchanged — UE's platform layer delegates to the same Win32 calls internally.

**4 files changed, ~213 insertions, ~276 deletions.**

## Motivation

The plugin currently cannot compile or run on Linux because it directly calls Win32 APIs (`CreateProcessW`, `CreatePipe`, `ReadFile`, `WriteFile`, `WaitForSingleObject`, clipboard APIs) and guards critical methods behind `#if PLATFORM_WINDOWS`. UE5 provides cross-platform equivalents for all of these through `FPlatformProcess`, making a clean port possible without architectural changes.

## Detailed Changes

### 1. `UnrealClaude.uplugin`
- Added `"Linux"` to `SupportedTargetPlatforms` array
- Added `"Linux"` to module `PlatformAllowList`
- Removed "Windows only" from plugin description

### 2. `ClaudeCodeRunner.h`
- Removed `#if PLATFORM_WINDOWS` / `#endif` guards around method declarations (`CreateProcessPipes`, `LaunchProcess`, `ReadProcessOutput`, `ReportError`, `ReportCompletion`)
- Changed `ProcessHandle` member from `void*` to `FProcHandle` (UE's cross-platform process handle type)
- Removed `LastProcessError` member (Win32-specific `DWORD` error code)
- Added `#include "HAL/PlatformProcess.h"`
- Updated class doc comment from "Windows implementation" to "cross-platform implementation"

### 3. `ClaudeCodeRunner.cpp` (major rewrite)

**Removed entirely:**
- `#include "Windows/WindowsHWrapper.h"`, `<windows.h>`, and the Allow/Hide wrappers
- `GetWindowsErrorMessage()` helper (Win32 `FormatMessageW` + error code switch)
- `EscapeCommandLineArg()` helper (Win32 `CreateProcessW` argument escaping — not needed when using `FPlatformProcess::CreateProc` which handles this internally)

**API replacements (no `#ifdef` needed — single cross-platform code path):**

| Original Win32 API | UE5 Replacement |
|---|---|
| `CreatePipe()` + `SECURITY_ATTRIBUTES` + `SetHandleInformation()` | `FPlatformProcess::CreatePipe(ReadPipe, WritePipe)` |
| `CreateProcessW()` + `STARTUPINFOW` + `PROCESS_INFORMATION` | `FPlatformProcess::CreateProc(...)` |
| `ReadFile()` loop with `char Buffer[4096]` | `FPlatformProcess::ReadPipe(ReadPipe)` (returns `FString` directly) |
| `WriteFile()` with `FTCHARToUTF8` conversion | `FPlatformProcess::WritePipe(WritePipe, Payload)` |
| `WaitForSingleObject(hProcess, timeout)` | `FPlatformProcess::IsProcRunning(ProcessHandle)` + `Sleep(0.01f)` |
| `TerminateProcess()` | `FPlatformProcess::TerminateProc(ProcessHandle, true)` |
| `GetExitCodeProcess()` | `FPlatformProcess::GetProcReturnCode(ProcessHandle, &ExitCode)` |
| `CloseHandle()` (per-handle) | `FPlatformProcess::ClosePipe()` / `CloseProc()` |

**Platform-specific path discovery (`GetClaudePath()`):**
- Windows (unchanged): searches `%USERPROFILE%\.local\bin\claude.exe`, `%APPDATA%\npm\claude.cmd`, `%LOCALAPPDATA%\npm\claude.cmd`, `PATH` entries, and falls back to `where claude`
- Linux (new): searches `$HOME/.local/bin/claude`, `/usr/local/bin/claude`, `/usr/bin/claude`, `$HOME/.npm-global/bin/claude`, `PATH` entries (split on `:`), and falls back to `/usr/bin/which claude`

**`IsClaudeAvailable()`:** Removed the `#if PLATFORM_WINDOWS` guard that always returned `false` on non-Windows. Now calls `GetClaudePath()` unconditionally.

**`Cancel()` thread safety:** Simplified from Win32 `InterlockedExchangePtr` pattern to just setting `StopTaskCounter` and terminating the process. Pipe/handle cleanup is left to `ExecuteProcess()` on the worker thread to avoid race conditions (the original pattern was needed because Win32 `HANDLE` values were stored as `void*` and had to be atomically extracted).

**Unchanged logic:** All NDJSON parsing, `ParseAndEmitNdjsonLine()`, `ParseStreamJsonOutput()`, `BuildStreamJsonPayload()`, `BuildCommandLine()`, stream event emission, and MCP config generation are completely untouched.

### 4. `ClipboardImageUtils.cpp`
- Added `#include "HAL/PlatformProcess.h"`
- **`ClipboardHasImage()`**: Added `#elif PLATFORM_LINUX` block that checks for image data via:
  1. `wl-paste --list-types` (Wayland) — looks for `image/png` or `image/` MIME types
  2. `xclip -selection clipboard -t TARGETS -o` (X11 fallback) — looks for `image/png`
- **`SaveClipboardImageToFile()`**: Added `#elif PLATFORM_LINUX` block that saves clipboard image via:
  1. `wl-paste --type image/png > file.png` (Wayland, via `/bin/sh -c`)
  2. `xclip -selection clipboard -t image/png -o > file.png` (X11 fallback, via `/bin/sh -c`)
  3. Cleans up empty/failed files on error
  4. Logs which tool was used on success
- Windows clipboard code (`OpenClipboard`, `GetClipboardData(CF_DIB)`, BITMAPINFOHEADER parsing) is completely unchanged
- `CleanupOldScreenshots()` and `GetScreenshotDirectory()` were already cross-platform

### 5. `UnrealClaude.Build.cs` — No changes needed
The existing Win64 guard for `ApplicationCore` and `LiveCoding` modules is already correct (those modules are Windows-only). All other module dependencies are cross-platform.

## What's NOT Changed
- All MCP tools (HTTP-based, already cross-platform)
- `UnrealClaudeMCPServer.cpp/h` (UE HTTPServer module)
- All Blueprint/Animation/Asset manipulation code
- UI widgets (Slate is cross-platform)
- Node.js MCP bridge (`index.js`, `lib.js`)
- `ClaudeSubsystem`, `ClaudeSessionManager`, `ClaudeEditorWidget`
- JSON parsing, stream-json payload building, command-line construction

## Testing Notes

### Windows regression testing
- [ ] Plugin loads in UE 5.7 editor
- [ ] `IsClaudeAvailable()` finds `claude.exe`/`claude.cmd`
- [ ] `ExecuteAsync()` spawns `claude -p`, streams NDJSON, returns results
- [ ] Clipboard image paste works (Ctrl+V with image in clipboard)
- [ ] MCP bridge tools work (Node.js subprocess)
- [ ] Cancel mid-execution works without crashes

### Linux testing
- [ ] Plugin compiles with UE 5.7 Linux editor build
- [ ] `GetClaudePath()` discovers `claude` binary from `~/.local/bin` or `PATH`
- [ ] `ExecuteAsync()` spawns `claude -p`, streams NDJSON output correctly
- [ ] Process termination via `Cancel()` works cleanly
- [ ] Clipboard image paste works with `wl-paste` (Wayland) installed
- [ ] Clipboard image paste works with `xclip` (X11) installed
- [ ] Graceful fallback when neither clipboard tool is installed
- [ ] MCP bridge works identically (Node.js, no changes needed)

### Linux clipboard prerequisites
```bash
# Wayland (preferred)
sudo apt install wl-clipboard    # provides wl-paste

# X11 (fallback)
sudo apt install xclip
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)