### PR TITLE
feat: add Linux (Wayland/Rocky 9) support and dependency guide

### DIFF
--- a/INSTALL_LINUX.md
+++ b/INSTALL_LINUX.md
@@ -1,0 +1,117 @@
+# Linux Installation Guide for UnrealClaude
+
+Verified on **Bazzite** (Fedora-based Atomic) host with a **Rocky Linux 9** Distrobox container, **UE 5.7**, and **NVIDIA RTX 4070** (Driver 590.48).
+
+## System Dependencies
+
+Install the required libraries (Rocky Linux 9 / Fedora):
+
+```bash
+sudo dnf install -y \
+  nss nspr mesa-libgbm \
+  libXcomposite libXdamage libXrandr \
+  alsa-lib pciutils-libs libXcursor \
+  atk at-spi2-atk \
+  pango cairo gdk-pixbuf2 gtk3
+```
+
+These resolve common `libnss3.so` and `libatk-1.0.so` errors when launching the Unreal Editor on Linux.
+
+## Clipboard Support
+
+UnrealClaude supports clipboard image paste on Linux via two backends:
+
+- **Wayland** (preferred): Requires `wl-clipboard`
+- **X11** (fallback): Requires `xclip`
+
+```bash
+# Wayland (most modern Fedora/Bazzite setups)
+sudo dnf install -y wl-clipboard
+
+# X11 / XWayland fallback
+sudo dnf install -y xclip
+```
+
+## Wayland Setup
+
+If you are running a Wayland session (default on Fedora 42+, Bazzite, etc.), set these environment variables before launching the editor:
+
+```bash
+export SDL_VIDEODRIVER=wayland
+export UE_Linux_EnableWaylandNative=1
+```
+
+You can add these to your `~/.bashrc` or create a launch wrapper script.
+
+## NVIDIA Vulkan in Containers (Distrobox)
+
+If running UE 5.7 inside a Distrobox or similar container, you may need to point Vulkan to the correct NVIDIA ICD:
+
+```bash
+export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json
+```
+
+Verify Vulkan is working:
+
+```bash
+vulkaninfo --summary
+```
+
+## Building the Plugin from Source
+
+Linux users must compile the plugin from source (no prebuilt binaries are provided).
+
+```bash
+# Replace with your UE 5.7 install path
+UE_ROOT=/path/to/UnrealEngine
+
+$UE_ROOT/Engine/Build/BatchFiles/RunUAT.sh BuildPlugin \
+  -Plugin="$(pwd)/UnrealClaude/UnrealClaude.uplugin" \
+  -Package="$(pwd)/BuiltPlugin" \
+  -TargetPlatforms=Linux
+```
+
+## MCP Bridge Setup
+
+The MCP bridge requires Node.js >= 18.0.0:
+
+```bash
+# Install Node.js (Fedora)
+sudo dnf install -y nodejs npm
+
+# Verify version
+node --version  # must be >= 18.0.0
+
+# Install bridge dependencies
+cd UnrealClaude/Resources/mcp-bridge
+npm install
+```
+
+## Claude CLI
+
+Install the Claude Code CLI:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+The plugin searches for the `claude` binary in these locations (in order):
+
+1. `~/.local/bin/claude`
+2. `/usr/local/bin/claude`
+3. `/usr/bin/claude`
+4. `~/.npm-global/bin/claude`
+5. nvm-managed Node.js directories
+6. Anywhere on your `PATH`
+
+## Launch
+
+```bash
+./UnrealEditor -vulkan
+```
+
+Or with explicit Wayland support:
+
+```bash
+SDL_VIDEODRIVER=wayland UE_Linux_EnableWaylandNative=1 ./UnrealEditor -vulkan
+```

--- a/README.md
+++ b/README.md
@@ -300,6 +300,29 @@ npm test
 This tests the bridge without requiring a running Unreal Editor.
 
 
+## Linux Quick Start (Rocky/Fedora)
+
+For full details, see [INSTALL_LINUX.md](INSTALL_LINUX.md).
+
+1. **Install Libraries:**
+   ```bash
+   sudo dnf install -y nss nspr mesa-libgbm libXcomposite libXdamage libXrandr alsa-lib pciutils-libs libXcursor atk at-spi2-atk pango cairo gdk-pixbuf2 gtk3
+   ```
+2. **Install Clipboard Support:**
+   ```bash
+   sudo dnf install -y wl-clipboard   # Wayland
+   sudo dnf install -y xclip          # X11 fallback
+   ```
+3. **Setup Wayland:**
+   ```bash
+   export SDL_VIDEODRIVER=wayland
+   export UE_Linux_EnableWaylandNative=1
+   ```
+4. **Build and Launch:**
+   ```bash
+   ./UnrealEditor -vulkan
+   ```
+
 ## Contributing
 
 Feel free to fork for your own needs! Possible areas for improvement:

--- a/UnrealClaude/Source/UnrealClaude/Private/ClaudeCodeRunner.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ClaudeCodeRunner.cpp
@@ -174,11 +174,14 @@ FString FClaudeCodeRunner::GetClaudePath()
 
 #if PLATFORM_WINDOWS
 	const TCHAR* WhichCmd = TEXT("where");
+	const TCHAR* WhichArgs = TEXT("claude");
 #else
-	const TCHAR* WhichCmd = TEXT("/usr/bin/which");
+	// Route through /bin/sh for PATH resolution (consistent with clipboard handling)
+	const TCHAR* WhichCmd = TEXT("/bin/sh");
+	const TCHAR* WhichArgs = TEXT("-c 'which claude 2>/dev/null'");
 #endif
 
-	if (FPlatformProcess::ExecProcess(WhichCmd, TEXT("claude"), &ReturnCode, &WhereOutput, &WhereErrors) && ReturnCode == 0)
+	if (FPlatformProcess::ExecProcess(WhichCmd, WhichArgs, &ReturnCode, &WhereOutput, &WhereErrors) && ReturnCode == 0)
 	{
 		WhereOutput.TrimStartAndEndInline();
 		TArray<FString> Lines;


### PR DESCRIPTION
## Description

This PR adds support for running the **UnrealClaude** plugin on Linux. While the core logic of the plugin is cross-platform, Linux users—specifically those on Wayland or atomic distributions like Bazzite—often face missing library dependencies or display backend hurdles.

Identified the minimal set of dependencies required for the plugin to function within a Rocky Linux 9 environment (the VFX standard) and provided the necessary launch flags to enable native Wayland support in UE 5.7.

## Changes

* **`INSTALL_LINUX.md`** — Comprehensive Linux installation guide covering:
  - System library dependencies (`libnss3`, `libatk`, etc.)
  - Wayland setup (`SDL_VIDEODRIVER`, `UE_Linux_EnableWaylandNative`)
  - NVIDIA Vulkan ICD configuration for containers (Distrobox)
  - Building the plugin from source
  - MCP bridge and Claude CLI setup
* **`README.md`** — Added Linux Quick Start section with dependency install, Wayland flags, and launch command
* **`ClaudeCodeRunner.cpp`** — Fixed hardcoded `/usr/bin/which` fallback to use `/bin/sh -c 'which claude'` for portable PATH resolution (consistent with the clipboard fix in 784c4ab)

## How has this been tested?

* **Host OS:** Bazzite (Fedora-based, Atomic)
* **Container:** Distrobox (Rocky Linux 9 image)
* **Engine Version:** Unreal Engine 5.7
* **Hardware:** NVIDIA GeForce RTX 4070 (Driver 590.48)
* **Node.js:** v22.22.0
* **Results:**
  - Successfully resolved `libnss3.so` and `libatk-1.0.so` errors
  - Verified Vulkan rendering inside the container using native Wayland backends
  - Confirmed the MCP bridge correctly connects Claude Code to the Unreal Editor
  - Claude CLI discovered at `~/.local/bin/claude` (first path checked)

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Documentation has been updated
- [x] Tested in a clean environment (Distrobox)
- [x] No breaking changes to Windows builds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)