### PR TITLE
feat: add material creation, preview, live coding, and editor exit tools

### DIFF
--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/MCPToolRegistry.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/MCPToolRegistry.cpp
@@ -28,6 +28,10 @@
 #include "Tools/MCPTool_Character.h"
 #include "Tools/MCPTool_CharacterData.h"
 #include "Tools/MCPTool_Material.h"
+#include "Tools/MCPTool_MaterialCreate.h"
+#include "Tools/MCPTool_MaterialPreview.h"
+#include "Tools/MCPTool_LiveCoding.h"
+#include "Tools/MCPTool_EditorExit.h"
 #include "Tools/MCPTool_Asset.h"
 #include "Tools/MCPTool_OpenLevel.h"
 
@@ -105,10 +109,18 @@ void FMCPToolRegistry::RegisterBuiltinTools()
 
 	// Material and Asset tools
 	RegisterTool(MakeShared<FMCPTool_Material>());
+	RegisterTool(MakeShared<FMCPTool_MaterialCreate>());
+	RegisterTool(MakeShared<FMCPTool_MaterialPreview>());
 	RegisterTool(MakeShared<FMCPTool_Asset>());
 
 	// Level management tools
 	RegisterTool(MakeShared<FMCPTool_OpenLevel>());
+
+	// Build tools
+	RegisterTool(MakeShared<FMCPTool_LiveCoding>());
+
+	// Editor control
+	RegisterTool(MakeShared<FMCPTool_EditorExit>());
 
 	// Create and register async task queue tools
 	// Task queue takes a raw pointer since the registry always outlives it

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_EditorExit.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_EditorExit.cpp
@@ -1,0 +1,45 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#include "MCPTool_EditorExit.h"
+#include "MCP/MCPParamValidator.h"
+#include "UnrealClaudeModule.h"
+#include "Editor.h"
+#include "Framework/Application/SlateApplication.h"
+
+FMCPToolInfo FMCPTool_EditorExit::GetInfo() const
+{
+	FMCPToolInfo Info;
+	Info.Name = TEXT("editor_exit");
+	Info.Description = TEXT("Request editor to close. Shows save dialog for unsaved changes - user decides whether to save.");
+
+	// No parameters needed - always shows save dialog
+
+	Info.Annotations = FMCPToolAnnotations::Destructive(TEXT("Closes the editor"));
+
+	return Info;
+}
+
+FMCPToolResult FMCPTool_EditorExit::Execute(const TSharedRef<FJsonObject>& Params)
+{
+	UE_LOG(LogUnrealClaude, Log, TEXT("Requesting editor exit - save dialog will appear if there are unsaved changes"));
+
+	// Request the main window to close - this triggers the standard exit flow
+	// which includes prompting to save dirty packages
+	if (FSlateApplication::IsInitialized())
+	{
+		TSharedPtr<SWindow> MainWindow = FSlateApplication::Get().GetActiveTopLevelWindow();
+		if (MainWindow.IsValid())
+		{
+			MainWindow->RequestDestroyWindow();
+		}
+	}
+
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetBoolField(TEXT("exit_requested"), true);
+	ResultData->SetStringField(TEXT("note"), TEXT("Save dialog will appear if there are unsaved changes. User must confirm."));
+
+	return FMCPToolResult::Success(
+		TEXT("Editor exit requested - save dialog will appear for unsaved changes"),
+		ResultData
+	);
+}

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_EditorExit.h
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_EditorExit.h
@@ -1,0 +1,15 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#pragma once
+
+#include "MCP/MCPToolBase.h"
+
+/**
+ * MCP Tool for requesting editor exit with save dialog.
+ */
+class FMCPTool_EditorExit : public FMCPToolBase
+{
+public:
+	virtual FMCPToolInfo GetInfo() const override;
+	virtual FMCPToolResult Execute(const TSharedRef<FJsonObject>& Params) override;
+};

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_LiveCoding.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_LiveCoding.cpp
@@ -1,0 +1,107 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#include "MCPTool_LiveCoding.h"
+#include "MCP/MCPParamValidator.h"
+#include "UnrealClaudeModule.h"
+
+#if WITH_LIVE_CODING
+#include "ILiveCodingModule.h"
+#endif
+
+FMCPToolInfo FMCPTool_LiveCoding::GetInfo() const
+{
+	FMCPToolInfo Info;
+	Info.Name = TEXT("live_coding");
+	Info.Description = TEXT("Trigger Live Coding hot reload compilation (equivalent to Ctrl+Alt+F11)");
+
+	Info.Parameters.Add(FMCPToolParameter(TEXT("operation"), TEXT("string"),
+		TEXT("Operation: compile, status (default: compile)")));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("timeout"), TEXT("number"),
+		TEXT("Max wait time in seconds for compilation (default: 60)")));
+
+	Info.Annotations = FMCPToolAnnotations::Modifying();
+
+	return Info;
+}
+
+FMCPToolResult FMCPTool_LiveCoding::Execute(const TSharedRef<FJsonObject>& Params)
+{
+#if WITH_LIVE_CODING
+	FString Operation = TEXT("compile");
+	if (Params->HasField(TEXT("operation")))
+	{
+		Operation = Params->GetStringField(TEXT("operation")).ToLower();
+	}
+
+	ILiveCodingModule* LiveCoding = FModuleManager::GetModulePtr<ILiveCodingModule>("LiveCoding");
+	if (!LiveCoding)
+	{
+		return FMCPToolResult::Error(TEXT("Live Coding module not loaded"));
+	}
+
+	// Status check
+	if (Operation == TEXT("status"))
+	{
+		TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+		ResultData->SetBoolField(TEXT("enabled"), LiveCoding->IsEnabledForSession());
+		ResultData->SetBoolField(TEXT("compiling"), LiveCoding->IsCompiling());
+
+		return FMCPToolResult::Success(
+			LiveCoding->IsEnabledForSession() ? TEXT("Live Coding is enabled") : TEXT("Live Coding is disabled"),
+			ResultData
+		);
+	}
+
+	// Compile
+	if (Operation == TEXT("compile"))
+	{
+		if (!LiveCoding->IsEnabledForSession())
+		{
+			return FMCPToolResult::Error(TEXT("Live Coding is not enabled for this session. User must press Ctrl+Alt+F11 first to enable it."));
+		}
+
+		if (LiveCoding->IsCompiling())
+		{
+			return FMCPToolResult::Error(TEXT("Live Coding is already compiling"));
+		}
+
+		// Trigger compilation
+		LiveCoding->Compile(ELiveCodingCompileFlags::None, nullptr);
+
+		// Wait for compilation
+		float MaxWait = 60.0f;
+		if (Params->HasField(TEXT("timeout")))
+		{
+			MaxWait = FMath::Clamp((float)Params->GetNumberField(TEXT("timeout")), 5.0f, 300.0f);
+		}
+
+		float WaitTime = 0.0f;
+		const float PollInterval = 0.5f;
+
+		while (LiveCoding->IsCompiling() && WaitTime < MaxWait)
+		{
+			FPlatformProcess::Sleep(PollInterval);
+			WaitTime += PollInterval;
+		}
+
+		if (WaitTime >= MaxWait)
+		{
+			return FMCPToolResult::Error(FString::Printf(TEXT("Live Coding compilation timed out after %.0f seconds"), MaxWait));
+		}
+
+		TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+		ResultData->SetNumberField(TEXT("compile_time_seconds"), WaitTime);
+		ResultData->SetBoolField(TEXT("success"), true);
+
+		return FMCPToolResult::Success(
+			FString::Printf(TEXT("Live Coding compilation completed in %.1f seconds"), WaitTime),
+			ResultData
+		);
+	}
+
+	return FMCPToolResult::Error(FString::Printf(TEXT("Unknown operation: %s. Valid: compile, status"), *Operation));
+
+#else
+	return FMCPToolResult::Error(TEXT("Live Coding is not available in this build"));
+#endif
+}

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_LiveCoding.h
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_LiveCoding.h
@@ -1,0 +1,15 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#pragma once
+
+#include "MCP/MCPToolBase.h"
+
+/**
+ * MCP Tool for triggering Live Coding (hot reload) compilation.
+ */
+class FMCPTool_LiveCoding : public FMCPToolBase
+{
+public:
+	virtual FMCPToolInfo GetInfo() const override;
+	virtual FMCPToolResult Execute(const TSharedRef<FJsonObject>& Params) override;
+};

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_Material.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_Material.cpp
@@ -10,6 +10,9 @@
 #include "Materials/MaterialInstance.h"
 #include "Materials/MaterialInstanceConstant.h"
 #include "Materials/MaterialInstanceDynamic.h"
+#include "Materials/MaterialExpressionCustom.h"
+#include "Materials/MaterialExpressionScalarParameter.h"
+#include "Materials/MaterialExpressionVectorParameter.h"
 #include "Engine/SkeletalMesh.h"
 #include "Engine/Texture.h"
 #include "Engine/Texture2D.h"
@@ -652,6 +655,91 @@ TSharedPtr<FJsonObject> FMCPTool_Material::BuildMaterialInfoJson(UMaterialInterf
 			TexturesObj->SetStringField(Param.ParameterInfo.Name.ToString(), TexturePath);
 		}
 		Info->SetObjectField(TEXT("texture_parameters"), TexturesObj);
+	}
+	else if (UMaterial* BaseMat = Cast<UMaterial>(Material))
+	{
+		Info->SetBoolField(TEXT("is_instance"), false);
+
+		// Material properties
+		Info->SetStringField(TEXT("blend_mode"), StaticEnum<EBlendMode>()->GetNameStringByValue((int64)BaseMat->BlendMode));
+		Info->SetStringField(TEXT("shading_model"), BaseMat->GetShadingModels().GetFirstShadingModel() == MSM_Unlit ? TEXT("Unlit") : TEXT("Lit"));
+		Info->SetBoolField(TEXT("two_sided"), BaseMat->TwoSided);
+
+		// Get expressions (nodes)
+		TArray<TSharedPtr<FJsonValue>> ExpressionsArray;
+		TArray<TSharedPtr<FJsonValue>> ParametersArray;
+		TArray<TSharedPtr<FJsonValue>> CustomNodesArray;
+
+		for (UMaterialExpression* Expr : BaseMat->GetExpressions())
+		{
+			TSharedPtr<FJsonObject> ExprObj = MakeShared<FJsonObject>();
+			ExprObj->SetStringField(TEXT("type"), Expr->GetClass()->GetName());
+			ExprObj->SetStringField(TEXT("desc"), Expr->GetDescription());
+
+			// Check for scalar parameter
+			if (UMaterialExpressionScalarParameter* ScalarParam = Cast<UMaterialExpressionScalarParameter>(Expr))
+			{
+				TSharedPtr<FJsonObject> ParamObj = MakeShared<FJsonObject>();
+				ParamObj->SetStringField(TEXT("name"), ScalarParam->ParameterName.ToString());
+				ParamObj->SetStringField(TEXT("type"), TEXT("scalar"));
+				ParamObj->SetNumberField(TEXT("default"), ScalarParam->DefaultValue);
+				ParametersArray.Add(MakeShared<FJsonValueObject>(ParamObj));
+			}
+			// Check for vector parameter
+			else if (UMaterialExpressionVectorParameter* VectorParam = Cast<UMaterialExpressionVectorParameter>(Expr))
+			{
+				TSharedPtr<FJsonObject> ParamObj = MakeShared<FJsonObject>();
+				ParamObj->SetStringField(TEXT("name"), VectorParam->ParameterName.ToString());
+				ParamObj->SetStringField(TEXT("type"), TEXT("vector"));
+				TSharedPtr<FJsonObject> DefVal = MakeShared<FJsonObject>();
+				DefVal->SetNumberField(TEXT("r"), VectorParam->DefaultValue.R);
+				DefVal->SetNumberField(TEXT("g"), VectorParam->DefaultValue.G);
+				DefVal->SetNumberField(TEXT("b"), VectorParam->DefaultValue.B);
+				DefVal->SetNumberField(TEXT("a"), VectorParam->DefaultValue.A);
+				ParamObj->SetObjectField(TEXT("default"), DefVal);
+				ParametersArray.Add(MakeShared<FJsonValueObject>(ParamObj));
+			}
+			// Check for Custom node
+			else if (UMaterialExpressionCustom* CustomNode = Cast<UMaterialExpressionCustom>(Expr))
+			{
+				TSharedPtr<FJsonObject> CustomObj = MakeShared<FJsonObject>();
+				CustomObj->SetStringField(TEXT("description"), CustomNode->Description);
+				CustomObj->SetStringField(TEXT("output_type"), StaticEnum<ECustomMaterialOutputType>()->GetNameStringByValue((int64)CustomNode->OutputType));
+				CustomObj->SetNumberField(TEXT("code_length"), CustomNode->Code.Len());
+
+				// List inputs
+				TArray<TSharedPtr<FJsonValue>> InputsArray;
+				for (const FCustomInput& Input : CustomNode->Inputs)
+				{
+					TSharedPtr<FJsonObject> InputObj = MakeShared<FJsonObject>();
+					InputObj->SetStringField(TEXT("name"), Input.InputName.ToString());
+					InputObj->SetBoolField(TEXT("connected"), Input.Input.Expression != nullptr);
+					if (Input.Input.Expression)
+					{
+						InputObj->SetStringField(TEXT("connected_to"), Input.Input.Expression->GetDescription());
+					}
+					InputsArray.Add(MakeShared<FJsonValueObject>(InputObj));
+				}
+				CustomObj->SetArrayField(TEXT("inputs"), InputsArray);
+				CustomNodesArray.Add(MakeShared<FJsonValueObject>(CustomObj));
+			}
+
+			ExpressionsArray.Add(MakeShared<FJsonValueObject>(ExprObj));
+		}
+
+		Info->SetNumberField(TEXT("expression_count"), ExpressionsArray.Num());
+		Info->SetArrayField(TEXT("parameters"), ParametersArray);
+		Info->SetArrayField(TEXT("custom_nodes"), CustomNodesArray);
+
+		// Check what's connected to emissive
+		if (BaseMat->GetEditorOnlyData() && BaseMat->GetEditorOnlyData()->EmissiveColor.Expression)
+		{
+			Info->SetStringField(TEXT("emissive_connected_to"), BaseMat->GetEditorOnlyData()->EmissiveColor.Expression->GetDescription());
+		}
+		else
+		{
+			Info->SetStringField(TEXT("emissive_connected_to"), TEXT("None"));
+		}
 	}
 	else
 	{

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_MaterialCreate.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_MaterialCreate.cpp
@@ -1,0 +1,862 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#include "MCPTool_MaterialCreate.h"
+#include "MCP/MCPParamValidator.h"
+#include "UnrealClaudeModule.h"
+
+#include "Materials/Material.h"
+#include "Materials/MaterialExpressionCustom.h"
+#include "Materials/MaterialExpressionScalarParameter.h"
+#include "Materials/MaterialExpressionVectorParameter.h"
+#include "MaterialEditingLibrary.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Factories/MaterialFactoryNew.h"
+#include "UObject/SavePackage.h"
+#include "Misc/PackageName.h"
+#include "EditorAssetLibrary.h"
+
+FMCPToolInfo FMCPTool_MaterialCreate::GetInfo() const
+{
+	FMCPToolInfo Info;
+	Info.Name = TEXT("material_create");
+	Info.Description = TEXT("Create and edit base materials with Custom HLSL nodes, parameters, and wiring");
+
+	Info.Parameters.Add(FMCPToolParameter(TEXT("operation"), TEXT("string"),
+		TEXT("Operation: create_material, add_custom_node, add_parameter, wire_to_custom, connect_output, set_custom_code, recompile_material, setup_corona_material"), true));
+
+	// Common
+	Info.Parameters.Add(FMCPToolParameter(TEXT("material_path"), TEXT("string"),
+		TEXT("Asset path to material (e.g., /Game/Materials/M_MyMaterial)")));
+
+	// create_material
+	Info.Parameters.Add(FMCPToolParameter(TEXT("blend_mode"), TEXT("string"),
+		TEXT("Blend mode: opaque, masked, translucent, additive, modulate (for create_material)")));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("shading_model"), TEXT("string"),
+		TEXT("Shading model: unlit, default_lit, subsurface, etc. (for create_material)")));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("two_sided"), TEXT("boolean"),
+		TEXT("Enable two-sided rendering (for create_material)")));
+
+	// add_custom_node
+	Info.Parameters.Add(FMCPToolParameter(TEXT("code"), TEXT("string"),
+		TEXT("HLSL code for Custom node (for add_custom_node, set_custom_code)")));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("description"), TEXT("string"),
+		TEXT("Description/name for Custom node (for add_custom_node)")));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("inputs"), TEXT("array"),
+		TEXT("Array of input names for Custom node (for add_custom_node)")));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("output_type"), TEXT("string"),
+		TEXT("Output type: float, float2, float3, float4 (for add_custom_node)")));
+
+	// add_parameter
+	Info.Parameters.Add(FMCPToolParameter(TEXT("param_name"), TEXT("string"),
+		TEXT("Parameter name (for add_parameter)")));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("param_type"), TEXT("string"),
+		TEXT("Parameter type: scalar, vector (for add_parameter)")));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("default_value"), TEXT("number|object"),
+		TEXT("Default value - number for scalar, {r,g,b,a} for vector (for add_parameter)")));
+
+	// wire_to_custom
+	Info.Parameters.Add(FMCPToolParameter(TEXT("custom_input"), TEXT("string"),
+		TEXT("Custom node input name to wire to (for wire_to_custom)")));
+
+	// connect_output
+	Info.Parameters.Add(FMCPToolParameter(TEXT("output_pin"), TEXT("string"),
+		TEXT("Material output: emissive, base_color, opacity, etc. (for connect_output)")));
+
+	// setup_corona_material - convenience operation
+	Info.Parameters.Add(FMCPToolParameter(TEXT("shader_file"), TEXT("string"),
+		TEXT("Path to .hlsl file to read code from (for setup_corona_material)")));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("parameters"), TEXT("array"),
+		TEXT("Array of {name, type, default} for parameters (for setup_corona_material)")));
+
+	Info.Annotations = FMCPToolAnnotations::Modifying();
+
+	return Info;
+}
+
+FMCPToolResult FMCPTool_MaterialCreate::Execute(const TSharedRef<FJsonObject>& Params)
+{
+	FString Operation;
+	TOptional<FMCPToolResult> Error;
+	if (!ExtractRequiredString(Params, TEXT("operation"), Operation, Error))
+	{
+		return Error.GetValue();
+	}
+
+	Operation = Operation.ToLower();
+
+	if (Operation == TEXT("create_material"))
+	{
+		return ExecuteCreateMaterial(Params);
+	}
+	else if (Operation == TEXT("add_custom_node"))
+	{
+		return ExecuteAddCustomNode(Params);
+	}
+	else if (Operation == TEXT("add_parameter"))
+	{
+		return ExecuteAddParameter(Params);
+	}
+	else if (Operation == TEXT("wire_to_custom"))
+	{
+		return ExecuteWireToCustom(Params);
+	}
+	else if (Operation == TEXT("connect_output"))
+	{
+		return ExecuteConnectOutput(Params);
+	}
+	else if (Operation == TEXT("set_custom_code"))
+	{
+		return ExecuteSetCustomCode(Params);
+	}
+	else if (Operation == TEXT("recompile_material"))
+	{
+		return ExecuteRecompileMaterial(Params);
+	}
+	else if (Operation == TEXT("setup_corona_material"))
+	{
+		return ExecuteSetupCoronaMaterial(Params);
+	}
+
+	return FMCPToolResult::Error(FString::Printf(
+		TEXT("Unknown operation: %s"), *Operation));
+}
+
+FMCPToolResult FMCPTool_MaterialCreate::ExecuteCreateMaterial(const TSharedRef<FJsonObject>& Params)
+{
+	FString MaterialPath;
+	TOptional<FMCPToolResult> Error;
+	if (!ExtractRequiredString(Params, TEXT("material_path"), MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+	if (!ValidateBlueprintPathParam(MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+
+	// Delete existing if present
+	if (UEditorAssetLibrary::DoesAssetExist(MaterialPath))
+	{
+		UEditorAssetLibrary::DeleteAsset(MaterialPath);
+	}
+
+	// Extract package path and asset name
+	FString PackagePath, AssetName;
+	MaterialPath.Split(TEXT("/"), &PackagePath, &AssetName, ESearchCase::IgnoreCase, ESearchDir::FromEnd);
+
+	// Create package
+	UPackage* Package = CreatePackage(*MaterialPath);
+	if (!Package)
+	{
+		return FMCPToolResult::Error(FString::Printf(TEXT("Failed to create package: %s"), *MaterialPath));
+	}
+
+	// Create material
+	UMaterialFactoryNew* Factory = NewObject<UMaterialFactoryNew>();
+	UMaterial* Material = Cast<UMaterial>(Factory->FactoryCreateNew(
+		UMaterial::StaticClass(),
+		Package,
+		FName(*AssetName),
+		RF_Public | RF_Standalone,
+		nullptr,
+		GWarn
+	));
+
+	if (!Material)
+	{
+		return FMCPToolResult::Error(TEXT("Failed to create material"));
+	}
+
+	// Set blend mode
+	if (Params->HasField(TEXT("blend_mode")))
+	{
+		FString BlendMode = Params->GetStringField(TEXT("blend_mode")).ToLower();
+		FString BlendError;
+		if (!SetMaterialBlendMode(Material, BlendMode, BlendError))
+		{
+			UE_LOG(LogUnrealClaude, Warning, TEXT("Blend mode warning: %s"), *BlendError);
+		}
+	}
+
+	// Set shading model
+	if (Params->HasField(TEXT("shading_model")))
+	{
+		FString ShadingModel = Params->GetStringField(TEXT("shading_model")).ToLower();
+		FString ShadingError;
+		if (!SetMaterialShadingModel(Material, ShadingModel, ShadingError))
+		{
+			UE_LOG(LogUnrealClaude, Warning, TEXT("Shading model warning: %s"), *ShadingError);
+		}
+	}
+
+	// Set two-sided
+	if (Params->HasField(TEXT("two_sided")))
+	{
+		Material->TwoSided = Params->GetBoolField(TEXT("two_sided"));
+	}
+
+	// Notify and save
+	FAssetRegistryModule::AssetCreated(Material);
+	Package->MarkPackageDirty();
+
+	FString PackageFileName = FPackageName::LongPackageNameToFilename(MaterialPath, FPackageName::GetAssetPackageExtension());
+	FSavePackageArgs SaveArgs;
+	SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+	UPackage::Save(Package, Material, *PackageFileName, SaveArgs);
+
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetStringField(TEXT("material_path"), MaterialPath);
+	ResultData->SetBoolField(TEXT("created"), true);
+
+	return FMCPToolResult::Success(
+		FString::Printf(TEXT("Created material: %s"), *MaterialPath),
+		ResultData
+	);
+}
+
+FMCPToolResult FMCPTool_MaterialCreate::ExecuteAddCustomNode(const TSharedRef<FJsonObject>& Params)
+{
+	FString MaterialPath, Code;
+	TOptional<FMCPToolResult> Error;
+	if (!ExtractRequiredString(Params, TEXT("material_path"), MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+	if (!ExtractRequiredString(Params, TEXT("code"), Code, Error))
+	{
+		return Error.GetValue();
+	}
+
+	FString LoadError;
+	UMaterial* Material = LoadOrCreateMaterial(MaterialPath, false, LoadError);
+	if (!Material)
+	{
+		return FMCPToolResult::Error(LoadError);
+	}
+
+	// Create Custom node
+	UMaterialExpressionCustom* CustomNode = Cast<UMaterialExpressionCustom>(
+		UMaterialEditingLibrary::CreateMaterialExpression(Material, UMaterialExpressionCustom::StaticClass(), -200, 0)
+	);
+
+	if (!CustomNode)
+	{
+		return FMCPToolResult::Error(TEXT("Failed to create Custom node"));
+	}
+
+	// Set code
+	CustomNode->Code = Code;
+
+	// Set description
+	if (Params->HasField(TEXT("description")))
+	{
+		CustomNode->Description = Params->GetStringField(TEXT("description"));
+	}
+
+	// Set output type
+	if (Params->HasField(TEXT("output_type")))
+	{
+		FString OutputType = Params->GetStringField(TEXT("output_type")).ToLower();
+		if (OutputType == TEXT("float") || OutputType == TEXT("float1"))
+		{
+			CustomNode->OutputType = CMOT_Float1;
+		}
+		else if (OutputType == TEXT("float2"))
+		{
+			CustomNode->OutputType = CMOT_Float2;
+		}
+		else if (OutputType == TEXT("float3"))
+		{
+			CustomNode->OutputType = CMOT_Float3;
+		}
+		else if (OutputType == TEXT("float4"))
+		{
+			CustomNode->OutputType = CMOT_Float4;
+		}
+	}
+
+	// Add inputs
+	const TArray<TSharedPtr<FJsonValue>>* InputsArray;
+	if (Params->TryGetArrayField(TEXT("inputs"), InputsArray))
+	{
+		CustomNode->Inputs.Empty();
+		for (const TSharedPtr<FJsonValue>& InputVal : *InputsArray)
+		{
+			FString InputName;
+			if (InputVal->TryGetString(InputName))
+			{
+				FCustomInput NewInput;
+				NewInput.InputName = FName(*InputName);
+				CustomNode->Inputs.Add(NewInput);
+			}
+		}
+	}
+
+	UMaterialEditingLibrary::RecompileMaterial(Material);
+
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetStringField(TEXT("material_path"), MaterialPath);
+	ResultData->SetStringField(TEXT("node_description"), CustomNode->Description);
+	ResultData->SetNumberField(TEXT("input_count"), CustomNode->Inputs.Num());
+
+	return FMCPToolResult::Success(
+		FString::Printf(TEXT("Added Custom node with %d inputs"), CustomNode->Inputs.Num()),
+		ResultData
+	);
+}
+
+FMCPToolResult FMCPTool_MaterialCreate::ExecuteAddParameter(const TSharedRef<FJsonObject>& Params)
+{
+	FString MaterialPath, ParamName, ParamType;
+	TOptional<FMCPToolResult> Error;
+	if (!ExtractRequiredString(Params, TEXT("material_path"), MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+	if (!ExtractRequiredString(Params, TEXT("param_name"), ParamName, Error))
+	{
+		return Error.GetValue();
+	}
+	if (!ExtractRequiredString(Params, TEXT("param_type"), ParamType, Error))
+	{
+		return Error.GetValue();
+	}
+
+	FString LoadError;
+	UMaterial* Material = LoadOrCreateMaterial(MaterialPath, false, LoadError);
+	if (!Material)
+	{
+		return FMCPToolResult::Error(LoadError);
+	}
+
+	ParamType = ParamType.ToLower();
+	int32 NodeY = Material->GetExpressions().Num() * 80; // Stack nodes vertically
+
+	if (ParamType == TEXT("scalar"))
+	{
+		UMaterialExpressionScalarParameter* Param = Cast<UMaterialExpressionScalarParameter>(
+			UMaterialEditingLibrary::CreateMaterialExpression(Material, UMaterialExpressionScalarParameter::StaticClass(), -500, NodeY)
+		);
+		if (Param)
+		{
+			Param->ParameterName = FName(*ParamName);
+			if (Params->HasField(TEXT("default_value")))
+			{
+				Param->DefaultValue = Params->GetNumberField(TEXT("default_value"));
+			}
+		}
+	}
+	else if (ParamType == TEXT("vector"))
+	{
+		UMaterialExpressionVectorParameter* Param = Cast<UMaterialExpressionVectorParameter>(
+			UMaterialEditingLibrary::CreateMaterialExpression(Material, UMaterialExpressionVectorParameter::StaticClass(), -500, NodeY)
+		);
+		if (Param)
+		{
+			Param->ParameterName = FName(*ParamName);
+			const TSharedPtr<FJsonObject>* DefaultObj;
+			if (Params->TryGetObjectField(TEXT("default_value"), DefaultObj))
+			{
+				FLinearColor Color(1, 1, 1, 1);
+				(*DefaultObj)->TryGetNumberField(TEXT("r"), Color.R);
+				(*DefaultObj)->TryGetNumberField(TEXT("g"), Color.G);
+				(*DefaultObj)->TryGetNumberField(TEXT("b"), Color.B);
+				(*DefaultObj)->TryGetNumberField(TEXT("a"), Color.A);
+				Param->DefaultValue = Color;
+			}
+		}
+	}
+	else
+	{
+		return FMCPToolResult::Error(FString::Printf(TEXT("Unknown param_type: %s. Use 'scalar' or 'vector'"), *ParamType));
+	}
+
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetStringField(TEXT("material_path"), MaterialPath);
+	ResultData->SetStringField(TEXT("param_name"), ParamName);
+	ResultData->SetStringField(TEXT("param_type"), ParamType);
+
+	return FMCPToolResult::Success(
+		FString::Printf(TEXT("Added %s parameter: %s"), *ParamType, *ParamName),
+		ResultData
+	);
+}
+
+FMCPToolResult FMCPTool_MaterialCreate::ExecuteWireToCustom(const TSharedRef<FJsonObject>& Params)
+{
+	FString MaterialPath, ParamName, CustomInput;
+	TOptional<FMCPToolResult> Error;
+	if (!ExtractRequiredString(Params, TEXT("material_path"), MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+	if (!ExtractRequiredString(Params, TEXT("param_name"), ParamName, Error))
+	{
+		return Error.GetValue();
+	}
+	if (!ExtractRequiredString(Params, TEXT("custom_input"), CustomInput, Error))
+	{
+		return Error.GetValue();
+	}
+
+	FString LoadError;
+	UMaterial* Material = LoadOrCreateMaterial(MaterialPath, false, LoadError);
+	if (!Material)
+	{
+		return FMCPToolResult::Error(LoadError);
+	}
+
+	// Find parameter node
+	UMaterialExpression* ParamNode = FindParameterNode(Material, ParamName);
+	if (!ParamNode)
+	{
+		return FMCPToolResult::Error(FString::Printf(TEXT("Parameter '%s' not found in material"), *ParamName));
+	}
+
+	// Find Custom node (first one, or by description if specified)
+	FString CustomDesc = Params->HasField(TEXT("description")) ? Params->GetStringField(TEXT("description")) : TEXT("");
+	UMaterialExpressionCustom* CustomNode = FindCustomNode(Material, CustomDesc);
+	if (!CustomNode)
+	{
+		return FMCPToolResult::Error(TEXT("No Custom node found in material"));
+	}
+
+	// Wire connection
+	bool bConnected = UMaterialEditingLibrary::ConnectMaterialExpressions(ParamNode, TEXT(""), CustomNode, CustomInput);
+	if (!bConnected)
+	{
+		return FMCPToolResult::Error(FString::Printf(TEXT("Failed to connect %s to Custom input %s"), *ParamName, *CustomInput));
+	}
+
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetStringField(TEXT("from"), ParamName);
+	ResultData->SetStringField(TEXT("to"), CustomInput);
+	ResultData->SetBoolField(TEXT("connected"), true);
+
+	return FMCPToolResult::Success(
+		FString::Printf(TEXT("Wired %s -> Custom.%s"), *ParamName, *CustomInput),
+		ResultData
+	);
+}
+
+FMCPToolResult FMCPTool_MaterialCreate::ExecuteConnectOutput(const TSharedRef<FJsonObject>& Params)
+{
+	FString MaterialPath, OutputPin;
+	TOptional<FMCPToolResult> Error;
+	if (!ExtractRequiredString(Params, TEXT("material_path"), MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+	if (!ExtractRequiredString(Params, TEXT("output_pin"), OutputPin, Error))
+	{
+		return Error.GetValue();
+	}
+
+	FString LoadError;
+	UMaterial* Material = LoadOrCreateMaterial(MaterialPath, false, LoadError);
+	if (!Material)
+	{
+		return FMCPToolResult::Error(LoadError);
+	}
+
+	// Find Custom node
+	FString CustomDesc = Params->HasField(TEXT("description")) ? Params->GetStringField(TEXT("description")) : TEXT("");
+	UMaterialExpressionCustom* CustomNode = FindCustomNode(Material, CustomDesc);
+	if (!CustomNode)
+	{
+		return FMCPToolResult::Error(TEXT("No Custom node found in material"));
+	}
+
+	// Map output pin name to enum
+	OutputPin = OutputPin.ToLower();
+	EMaterialProperty MatProp = MP_EmissiveColor; // Default
+
+	if (OutputPin == TEXT("emissive") || OutputPin == TEXT("emissive_color"))
+	{
+		MatProp = MP_EmissiveColor;
+	}
+	else if (OutputPin == TEXT("base_color") || OutputPin == TEXT("basecolor"))
+	{
+		MatProp = MP_BaseColor;
+	}
+	else if (OutputPin == TEXT("opacity"))
+	{
+		MatProp = MP_Opacity;
+	}
+	else if (OutputPin == TEXT("opacity_mask"))
+	{
+		MatProp = MP_OpacityMask;
+	}
+	else if (OutputPin == TEXT("metallic"))
+	{
+		MatProp = MP_Metallic;
+	}
+	else if (OutputPin == TEXT("roughness"))
+	{
+		MatProp = MP_Roughness;
+	}
+	else if (OutputPin == TEXT("normal"))
+	{
+		MatProp = MP_Normal;
+	}
+
+	bool bConnected = UMaterialEditingLibrary::ConnectMaterialProperty(CustomNode, TEXT(""), MatProp);
+	if (!bConnected)
+	{
+		return FMCPToolResult::Error(FString::Printf(TEXT("Failed to connect Custom to %s"), *OutputPin));
+	}
+
+	UMaterialEditingLibrary::RecompileMaterial(Material);
+
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetStringField(TEXT("output_pin"), OutputPin);
+	ResultData->SetBoolField(TEXT("connected"), true);
+
+	return FMCPToolResult::Success(
+		FString::Printf(TEXT("Connected Custom node to %s"), *OutputPin),
+		ResultData
+	);
+}
+
+FMCPToolResult FMCPTool_MaterialCreate::ExecuteSetCustomCode(const TSharedRef<FJsonObject>& Params)
+{
+	FString MaterialPath, Code;
+	TOptional<FMCPToolResult> Error;
+	if (!ExtractRequiredString(Params, TEXT("material_path"), MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+	if (!ExtractRequiredString(Params, TEXT("code"), Code, Error))
+	{
+		return Error.GetValue();
+	}
+
+	FString LoadError;
+	UMaterial* Material = LoadOrCreateMaterial(MaterialPath, false, LoadError);
+	if (!Material)
+	{
+		return FMCPToolResult::Error(LoadError);
+	}
+
+	FString CustomDesc = Params->HasField(TEXT("description")) ? Params->GetStringField(TEXT("description")) : TEXT("");
+	UMaterialExpressionCustom* CustomNode = FindCustomNode(Material, CustomDesc);
+	if (!CustomNode)
+	{
+		return FMCPToolResult::Error(TEXT("No Custom node found in material"));
+	}
+
+	CustomNode->Code = Code;
+	UMaterialEditingLibrary::RecompileMaterial(Material);
+
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetStringField(TEXT("material_path"), MaterialPath);
+	ResultData->SetNumberField(TEXT("code_length"), Code.Len());
+
+	return FMCPToolResult::Success(TEXT("Updated Custom node code"), ResultData);
+}
+
+FMCPToolResult FMCPTool_MaterialCreate::ExecuteRecompileMaterial(const TSharedRef<FJsonObject>& Params)
+{
+	FString MaterialPath;
+	TOptional<FMCPToolResult> Error;
+	if (!ExtractRequiredString(Params, TEXT("material_path"), MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+
+	FString LoadError;
+	UMaterial* Material = LoadOrCreateMaterial(MaterialPath, false, LoadError);
+	if (!Material)
+	{
+		return FMCPToolResult::Error(LoadError);
+	}
+
+	UMaterialEditingLibrary::RecompileMaterial(Material);
+	UEditorAssetLibrary::SaveAsset(MaterialPath);
+
+	return FMCPToolResult::Success(FString::Printf(TEXT("Recompiled material: %s"), *MaterialPath));
+}
+
+FMCPToolResult FMCPTool_MaterialCreate::ExecuteSetupCoronaMaterial(const TSharedRef<FJsonObject>& Params)
+{
+	FString MaterialPath;
+	TOptional<FMCPToolResult> Error;
+	if (!ExtractRequiredString(Params, TEXT("material_path"), MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+
+	// Read shader file if specified
+	FString Code = TEXT("return float3(1,0,1);"); // Default pink for error
+	if (Params->HasField(TEXT("shader_file")))
+	{
+		FString ShaderFile = Params->GetStringField(TEXT("shader_file"));
+		if (FFileHelper::LoadFileToString(Code, *ShaderFile))
+		{
+			UE_LOG(LogUnrealClaude, Log, TEXT("Loaded shader code from: %s"), *ShaderFile);
+		}
+		else
+		{
+			UE_LOG(LogUnrealClaude, Warning, TEXT("Failed to load shader file: %s"), *ShaderFile);
+		}
+	}
+	else if (Params->HasField(TEXT("code")))
+	{
+		Code = Params->GetStringField(TEXT("code"));
+	}
+
+	// Delete and recreate material
+	if (UEditorAssetLibrary::DoesAssetExist(MaterialPath))
+	{
+		UEditorAssetLibrary::DeleteAsset(MaterialPath);
+	}
+
+	FString PackagePath, AssetName;
+	MaterialPath.Split(TEXT("/"), &PackagePath, &AssetName, ESearchCase::IgnoreCase, ESearchDir::FromEnd);
+
+	UPackage* Package = CreatePackage(*MaterialPath);
+	UMaterialFactoryNew* Factory = NewObject<UMaterialFactoryNew>();
+	UMaterial* Material = Cast<UMaterial>(Factory->FactoryCreateNew(
+		UMaterial::StaticClass(), Package, FName(*AssetName),
+		RF_Public | RF_Standalone, nullptr, GWarn
+	));
+
+	if (!Material)
+	{
+		return FMCPToolResult::Error(TEXT("Failed to create material"));
+	}
+
+	// Set material properties
+	Material->BlendMode = BLEND_Additive;
+	Material->SetShadingModel(MSM_Unlit);
+	Material->TwoSided = true;
+
+	// Create parameters and Custom node
+	TArray<FString> ParamNames;
+	const TArray<TSharedPtr<FJsonValue>>* ParametersArray;
+	if (Params->TryGetArrayField(TEXT("parameters"), ParametersArray))
+	{
+		int32 YPos = 0;
+		for (const TSharedPtr<FJsonValue>& ParamVal : *ParametersArray)
+		{
+			const TSharedPtr<FJsonObject>* ParamObj;
+			if (ParamVal->TryGetObject(ParamObj))
+			{
+				FString PName = (*ParamObj)->GetStringField(TEXT("name"));
+				FString PType = (*ParamObj)->GetStringField(TEXT("type")).ToLower();
+				ParamNames.Add(PName);
+
+				if (PType == TEXT("scalar"))
+				{
+					UMaterialExpressionScalarParameter* Param = Cast<UMaterialExpressionScalarParameter>(
+						UMaterialEditingLibrary::CreateMaterialExpression(Material, UMaterialExpressionScalarParameter::StaticClass(), -600, YPos)
+					);
+					if (Param)
+					{
+						Param->ParameterName = FName(*PName);
+						if ((*ParamObj)->HasField(TEXT("default")))
+						{
+							Param->DefaultValue = (*ParamObj)->GetNumberField(TEXT("default"));
+						}
+					}
+				}
+				else if (PType == TEXT("vector"))
+				{
+					UMaterialExpressionVectorParameter* Param = Cast<UMaterialExpressionVectorParameter>(
+						UMaterialEditingLibrary::CreateMaterialExpression(Material, UMaterialExpressionVectorParameter::StaticClass(), -600, YPos)
+					);
+					if (Param)
+					{
+						Param->ParameterName = FName(*PName);
+						const TSharedPtr<FJsonObject>* DefObj;
+						if ((*ParamObj)->TryGetObjectField(TEXT("default"), DefObj))
+						{
+							FLinearColor Color(1, 1, 1, 1);
+							(*DefObj)->TryGetNumberField(TEXT("r"), Color.R);
+							(*DefObj)->TryGetNumberField(TEXT("g"), Color.G);
+							(*DefObj)->TryGetNumberField(TEXT("b"), Color.B);
+							(*DefObj)->TryGetNumberField(TEXT("a"), Color.A);
+							Param->DefaultValue = Color;
+						}
+					}
+				}
+				YPos += 80;
+			}
+		}
+	}
+
+	// Create Custom node
+	UMaterialExpressionCustom* CustomNode = Cast<UMaterialExpressionCustom>(
+		UMaterialEditingLibrary::CreateMaterialExpression(Material, UMaterialExpressionCustom::StaticClass(), -200, 100)
+	);
+
+	if (CustomNode)
+	{
+		CustomNode->Code = Code;
+		CustomNode->Description = TEXT("Corona Shader");
+		CustomNode->OutputType = CMOT_Float3;
+
+		// Add inputs matching parameters
+		CustomNode->Inputs.Empty();
+		for (const FString& PName : ParamNames)
+		{
+			FCustomInput NewInput;
+			NewInput.InputName = FName(*PName);
+			CustomNode->Inputs.Add(NewInput);
+		}
+
+		// Wire parameters to Custom inputs
+		for (const FString& PName : ParamNames)
+		{
+			UMaterialExpression* ParamNode = FindParameterNode(Material, PName);
+			if (ParamNode)
+			{
+				UMaterialEditingLibrary::ConnectMaterialExpressions(ParamNode, TEXT(""), CustomNode, PName);
+			}
+		}
+
+		// Connect to Emissive
+		UMaterialEditingLibrary::ConnectMaterialProperty(CustomNode, TEXT(""), MP_EmissiveColor);
+	}
+
+	// Recompile and save
+	UMaterialEditingLibrary::RecompileMaterial(Material);
+	FAssetRegistryModule::AssetCreated(Material);
+	Package->MarkPackageDirty();
+
+	FString PackageFileName = FPackageName::LongPackageNameToFilename(MaterialPath, FPackageName::GetAssetPackageExtension());
+	FSavePackageArgs SaveArgs;
+	SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+	UPackage::Save(Package, Material, *PackageFileName, SaveArgs);
+
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetStringField(TEXT("material_path"), MaterialPath);
+	ResultData->SetNumberField(TEXT("parameter_count"), ParamNames.Num());
+	ResultData->SetBoolField(TEXT("custom_node_created"), CustomNode != nullptr);
+
+	return FMCPToolResult::Success(
+		FString::Printf(TEXT("Created corona material with %d parameters"), ParamNames.Num()),
+		ResultData
+	);
+}
+
+// Helper implementations
+
+UMaterial* FMCPTool_MaterialCreate::LoadOrCreateMaterial(const FString& AssetPath, bool bCreateIfMissing, FString& OutError)
+{
+	UMaterial* Material = LoadObject<UMaterial>(nullptr, *AssetPath);
+	if (!Material)
+	{
+		OutError = FString::Printf(TEXT("Failed to load material: %s"), *AssetPath);
+	}
+	return Material;
+}
+
+UMaterialExpressionCustom* FMCPTool_MaterialCreate::FindCustomNode(UMaterial* Material, const FString& NodeDesc)
+{
+	if (!Material) return nullptr;
+
+	for (UMaterialExpression* Expr : Material->GetExpressions())
+	{
+		if (UMaterialExpressionCustom* Custom = Cast<UMaterialExpressionCustom>(Expr))
+		{
+			if (NodeDesc.IsEmpty() || Custom->Description.Contains(NodeDesc))
+			{
+				return Custom;
+			}
+		}
+	}
+	return nullptr;
+}
+
+UMaterialExpression* FMCPTool_MaterialCreate::FindParameterNode(UMaterial* Material, const FString& ParamName)
+{
+	if (!Material) return nullptr;
+
+	for (UMaterialExpression* Expr : Material->GetExpressions())
+	{
+		if (UMaterialExpressionScalarParameter* Scalar = Cast<UMaterialExpressionScalarParameter>(Expr))
+		{
+			if (Scalar->ParameterName.ToString() == ParamName)
+			{
+				return Scalar;
+			}
+		}
+		else if (UMaterialExpressionVectorParameter* Vector = Cast<UMaterialExpressionVectorParameter>(Expr))
+		{
+			if (Vector->ParameterName.ToString() == ParamName)
+			{
+				return Vector;
+			}
+		}
+	}
+	return nullptr;
+}
+
+bool FMCPTool_MaterialCreate::SetMaterialBlendMode(UMaterial* Material, const FString& BlendMode, FString& OutError)
+{
+	if (BlendMode == TEXT("opaque"))
+	{
+		Material->BlendMode = BLEND_Opaque;
+	}
+	else if (BlendMode == TEXT("masked"))
+	{
+		Material->BlendMode = BLEND_Masked;
+	}
+	else if (BlendMode == TEXT("translucent"))
+	{
+		Material->BlendMode = BLEND_Translucent;
+	}
+	else if (BlendMode == TEXT("additive"))
+	{
+		Material->BlendMode = BLEND_Additive;
+	}
+	else if (BlendMode == TEXT("modulate"))
+	{
+		Material->BlendMode = BLEND_Modulate;
+	}
+	else
+	{
+		OutError = FString::Printf(TEXT("Unknown blend mode: %s"), *BlendMode);
+		return false;
+	}
+	return true;
+}
+
+bool FMCPTool_MaterialCreate::SetMaterialShadingModel(UMaterial* Material, const FString& ShadingModel, FString& OutError)
+{
+	if (ShadingModel == TEXT("unlit"))
+	{
+		Material->SetShadingModel(MSM_Unlit);
+	}
+	else if (ShadingModel == TEXT("default_lit") || ShadingModel == TEXT("lit"))
+	{
+		Material->SetShadingModel(MSM_DefaultLit);
+	}
+	else if (ShadingModel == TEXT("subsurface"))
+	{
+		Material->SetShadingModel(MSM_Subsurface);
+	}
+	else if (ShadingModel == TEXT("preintegrated_skin"))
+	{
+		Material->SetShadingModel(MSM_PreintegratedSkin);
+	}
+	else if (ShadingModel == TEXT("clear_coat"))
+	{
+		Material->SetShadingModel(MSM_ClearCoat);
+	}
+	else if (ShadingModel == TEXT("subsurface_profile"))
+	{
+		Material->SetShadingModel(MSM_SubsurfaceProfile);
+	}
+	else if (ShadingModel == TEXT("two_sided_foliage"))
+	{
+		Material->SetShadingModel(MSM_TwoSidedFoliage);
+	}
+	else
+	{
+		OutError = FString::Printf(TEXT("Unknown shading model: %s"), *ShadingModel);
+		return false;
+	}
+	return true;
+}

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_MaterialCreate.h
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_MaterialCreate.h
@@ -1,0 +1,38 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#pragma once
+
+#include "MCP/MCPToolBase.h"
+
+class UMaterial;
+class UMaterialExpressionCustom;
+class UMaterialExpression;
+
+/**
+ * MCP Tool for creating base materials with Custom HLSL nodes.
+ * Handles material creation, expression nodes, wiring, and compilation.
+ */
+class FMCPTool_MaterialCreate : public FMCPToolBase
+{
+public:
+	virtual FMCPToolInfo GetInfo() const override;
+	virtual FMCPToolResult Execute(const TSharedRef<FJsonObject>& Params) override;
+
+private:
+	// Operations
+	FMCPToolResult ExecuteCreateMaterial(const TSharedRef<FJsonObject>& Params);
+	FMCPToolResult ExecuteAddCustomNode(const TSharedRef<FJsonObject>& Params);
+	FMCPToolResult ExecuteAddParameter(const TSharedRef<FJsonObject>& Params);
+	FMCPToolResult ExecuteWireToCustom(const TSharedRef<FJsonObject>& Params);
+	FMCPToolResult ExecuteConnectOutput(const TSharedRef<FJsonObject>& Params);
+	FMCPToolResult ExecuteSetCustomCode(const TSharedRef<FJsonObject>& Params);
+	FMCPToolResult ExecuteRecompileMaterial(const TSharedRef<FJsonObject>& Params);
+	FMCPToolResult ExecuteSetupCoronaMaterial(const TSharedRef<FJsonObject>& Params);
+
+	// Helpers
+	UMaterial* LoadOrCreateMaterial(const FString& AssetPath, bool bCreateIfMissing, FString& OutError);
+	UMaterialExpressionCustom* FindCustomNode(UMaterial* Material, const FString& NodeDesc);
+	UMaterialExpression* FindParameterNode(UMaterial* Material, const FString& ParamName);
+	bool SetMaterialBlendMode(UMaterial* Material, const FString& BlendMode, FString& OutError);
+	bool SetMaterialShadingModel(UMaterial* Material, const FString& ShadingModel, FString& OutError);
+};

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_MaterialPreview.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_MaterialPreview.cpp
@@ -1,0 +1,120 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#include "MCPTool_MaterialPreview.h"
+#include "MCP/MCPParamValidator.h"
+#include "UnrealClaudeModule.h"
+
+#include "ObjectTools.h"
+#include "Materials/MaterialInterface.h"
+#include "Misc/ObjectThumbnail.h"
+#include "IImageWrapperModule.h"
+#include "IImageWrapper.h"
+#include "Misc/Base64.h"
+
+FMCPToolInfo FMCPTool_MaterialPreview::GetInfo() const
+{
+	FMCPToolInfo Info;
+	Info.Name = TEXT("material_preview");
+	Info.Description = TEXT("Capture a material preview image (like the material editor preview sphere)");
+
+	Info.Parameters.Add(FMCPToolParameter(TEXT("material_path"), TEXT("string"),
+		TEXT("Asset path to the material (e.g., /Game/Materials/M_MyMaterial)"), true));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("size"), TEXT("integer"),
+		TEXT("Preview image size in pixels (default: 256, max: 1024)")));
+	Info.Parameters.Add(FMCPToolParameter(TEXT("quality"), TEXT("integer"),
+		TEXT("JPEG quality 1-100 (default: 85)")));
+
+	Info.Annotations = FMCPToolAnnotations::ReadOnly();
+
+	return Info;
+}
+
+FMCPToolResult FMCPTool_MaterialPreview::Execute(const TSharedRef<FJsonObject>& Params)
+{
+	// Extract material path
+	FString MaterialPath;
+	TOptional<FMCPToolResult> Error;
+	if (!ExtractRequiredString(Params, TEXT("material_path"), MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+	if (!ValidateBlueprintPathParam(MaterialPath, Error))
+	{
+		return Error.GetValue();
+	}
+
+	// Get optional parameters
+	int32 ImageSize = 256;
+	if (Params->HasField(TEXT("size")))
+	{
+		ImageSize = FMath::Clamp(Params->GetIntegerField(TEXT("size")), 64, 1024);
+	}
+
+	int32 Quality = 85;
+	if (Params->HasField(TEXT("quality")))
+	{
+		Quality = FMath::Clamp(Params->GetIntegerField(TEXT("quality")), 1, 100);
+	}
+
+	// Load the material
+	UMaterialInterface* Material = LoadObject<UMaterialInterface>(nullptr, *MaterialPath);
+	if (!Material)
+	{
+		return FMCPToolResult::Error(FString::Printf(TEXT("Failed to load material: %s"), *MaterialPath));
+	}
+
+	// Render thumbnail
+	FObjectThumbnail Thumbnail;
+	ThumbnailTools::RenderThumbnail(
+		Material,
+		ImageSize,
+		ImageSize,
+		ThumbnailTools::EThumbnailTextureFlushMode::AlwaysFlush,
+		nullptr,  // Use scratch render target
+		&Thumbnail
+	);
+
+	// Get raw pixel data
+	const TArray<uint8>& RawData = Thumbnail.GetUncompressedImageData();
+	if (RawData.Num() == 0)
+	{
+		return FMCPToolResult::Error(TEXT("Failed to render material preview - no image data returned"));
+	}
+
+	// Compress to JPEG
+	IImageWrapperModule& ImageWrapperModule = FModuleManager::LoadModuleChecked<IImageWrapperModule>("ImageWrapper");
+	TSharedPtr<IImageWrapper> ImageWrapper = ImageWrapperModule.CreateImageWrapper(EImageFormat::JPEG);
+
+	if (!ImageWrapper->SetRaw(
+		RawData.GetData(),
+		RawData.Num(),
+		Thumbnail.GetImageWidth(),
+		Thumbnail.GetImageHeight(),
+		ERGBFormat::BGRA,
+		8))
+	{
+		return FMCPToolResult::Error(TEXT("Failed to encode image data"));
+	}
+
+	TArray64<uint8> CompressedData = ImageWrapper->GetCompressed(Quality);
+	if (CompressedData.Num() == 0)
+	{
+		return FMCPToolResult::Error(TEXT("Failed to compress image to JPEG"));
+	}
+
+	// Encode as base64
+	FString Base64Image = FBase64::Encode(CompressedData.GetData(), CompressedData.Num());
+
+	// Build result
+	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
+	ResultData->SetStringField(TEXT("image_base64"), Base64Image);
+	ResultData->SetNumberField(TEXT("width"), Thumbnail.GetImageWidth());
+	ResultData->SetNumberField(TEXT("height"), Thumbnail.GetImageHeight());
+	ResultData->SetStringField(TEXT("format"), TEXT("jpeg"));
+	ResultData->SetStringField(TEXT("material_name"), Material->GetName());
+
+	return FMCPToolResult::Success(
+		FString::Printf(TEXT("Captured %dx%d preview of %s"), Thumbnail.GetImageWidth(), Thumbnail.GetImageHeight(), *Material->GetName()),
+		ResultData
+	);
+}

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_MaterialPreview.h
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_MaterialPreview.h
@@ -1,0 +1,16 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#pragma once
+
+#include "MCP/MCPToolBase.h"
+
+/**
+ * MCP Tool for capturing material preview images.
+ * Renders a material to a thumbnail and returns as base64.
+ */
+class FMCPTool_MaterialPreview : public FMCPToolBase
+{
+public:
+	virtual FMCPToolInfo GetInfo() const override;
+	virtual FMCPToolResult Execute(const TSharedRef<FJsonObject>& Params) override;
+};

--- a/UnrealClaude/Source/UnrealClaude/UnrealClaude.Build.cs
+++ b/UnrealClaude/Source/UnrealClaude/UnrealClaude.Build.cs
@@ -59,7 +59,9 @@ public class UnrealClaude : ModuleRules
 				// Asset saving
 				"EditorScriptingUtilities",
 				// Enhanced Input
-				"EnhancedInput"
+				"EnhancedInput",
+				// Material editing
+				"MaterialEditor"
 			}
 		);
 


### PR DESCRIPTION
## Summary

New MCP tools for material authoring workflow and editor control:

- **material_create**: Create materials with Custom HLSL nodes programmatically - add parameters, wire connections, set shader code all via MCP
- **material_preview**: Capture material preview thumbnail as base64 JPEG for visual feedback
- **live_coding**: Trigger hot reload compilation (equivalent to Ctrl+Alt+F11)
- **editor_exit**: Gracefully close the editor with save dialog for unsaved changes

Enhanced **get_material_info** in the existing material tool:
- Shows blend mode, shading model, two-sided status
- Shows parameter nodes with names, types, and default values
- Shows Custom HLSL nodes with code length, inputs, and connections

Also adds `MaterialEditor` module dependency for material graph manipulation.

## Test plan

- [ ] Create a new material via `material_create` with `create_material` operation
- [ ] Add scalar/vector parameters via `add_parameter`
- [ ] Add Custom HLSL node via `add_custom_node`
- [ ] Wire parameters to custom node via `wire_to_custom`
- [ ] Set HLSL code via `set_custom_code`
- [ ] Connect to output via `connect_output`
- [ ] Capture preview via `material_preview`
- [ ] Test `live_coding` compile and status operations
- [ ] Test `editor_exit` shows save dialog for dirty packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)