### PR TITLE
feat: handle streaming refusals (stop_reason: "refusal")

### DIFF
--- a/UnrealClaude/Source/UnrealClaude/Private/ClaudeCodeRunner.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ClaudeCodeRunner.cpp
@@ -550,7 +550,8 @@ FString FClaudeCodeRunner::ParseStreamJsonOutput(const FString& RawOutput)
 	TArray<FString> Lines;
 	RawOutput.ParseIntoArrayLines(Lines);
 
-	// First pass: look for the "result" message
+	// First pass: check for refusal (must take priority) and look for result message
+	FString FoundResultText;
 	for (const FString& Line : Lines)
 	{
 		if (Line.IsEmpty())
@@ -571,38 +572,7 @@ FString FClaudeCodeRunner::ParseStreamJsonOutput(const FString& RawOutput)
 			continue;
 		}
 
-		if (Type == TEXT("result"))
-		{
-			FString ResultText;
-			if (JsonObj->TryGetStringField(TEXT("result"), ResultText))
-			{
-				UE_LOG(LogUnrealClaude, Log, TEXT("Parsed stream-json result: %d chars"), ResultText.Len());
-				return ResultText;
-			}
-		}
-	}
-
-	// Check for refusal in assistant messages
-	for (const FString& Line : Lines)
-	{
-		if (Line.IsEmpty())
-		{
-			continue;
-		}
-
-		TSharedPtr<FJsonObject> JsonObj;
-		TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Line);
-		if (!FJsonSerializer::Deserialize(Reader, JsonObj) || !JsonObj.IsValid())
-		{
-			continue;
-		}
-
-		FString Type;
-		if (!JsonObj->TryGetStringField(TEXT("type"), Type))
-		{
-			continue;
-		}
-
+		// Check for refusal in assistant messages (stop_reason in message object)
 		if (Type == TEXT("assistant"))
 		{
 			const TSharedPtr<FJsonObject>* MessageObj;
@@ -611,11 +581,32 @@ FString FClaudeCodeRunner::ParseStreamJsonOutput(const FString& RawOutput)
 				FString StopReason;
 				if ((*MessageObj)->TryGetStringField(TEXT("stop_reason"), StopReason) && StopReason == TEXT("refusal"))
 				{
-					UE_LOG(LogUnrealClaude, Warning, TEXT("ParseStreamJsonOutput: Detected refusal (stop_reason=refusal)"));
+					UE_LOG(LogUnrealClaude, Warning, TEXT("ParseStreamJsonOutput: Detected refusal in assistant message"));
 					return TEXT("Error: Response refused by content safety filter. Please rephrase your request.");
 				}
 			}
 		}
+
+		// Check for refusal in result events (stop_reason at top level)
+		if (Type == TEXT("result"))
+		{
+			FString StopReason;
+			if (JsonObj->TryGetStringField(TEXT("stop_reason"), StopReason) && StopReason == TEXT("refusal"))
+			{
+				UE_LOG(LogUnrealClaude, Warning, TEXT("ParseStreamJsonOutput: Detected refusal in result event"));
+				return TEXT("Error: Response refused by content safety filter. Please rephrase your request.");
+			}
+
+			// Not a refusal — save the result text for later
+			JsonObj->TryGetStringField(TEXT("result"), FoundResultText);
+		}
+	}
+
+	// Return the result text if found (no refusal detected)
+	if (!FoundResultText.IsEmpty())
+	{
+		UE_LOG(LogUnrealClaude, Log, TEXT("Parsed stream-json result: %d chars"), FoundResultText.Len());
+		return FoundResultText;
 	}
 
 	// Fallback: accumulate text from assistant content blocks
@@ -745,6 +736,9 @@ void FClaudeCodeRunner::ParseAndEmitNdjsonLine(const FString& JsonLine)
 		{
 			UE_LOG(LogUnrealClaude, Warning, TEXT("NDJSON: Streaming refusal detected (stop_reason=refusal)"));
 
+			bRefusalDetected.Store(true);
+			AccumulatedResponseText.Empty();
+
 			if (CurrentConfig.OnStreamEvent.IsBound())
 			{
 				FClaudeStreamEvent Event;
@@ -758,6 +752,9 @@ void FClaudeCodeRunner::ParseAndEmitNdjsonLine(const FString& JsonLine)
 					EventDelegate.ExecuteIfBound(Event);
 				});
 			}
+
+			// Do not parse content blocks from a refused message
+			return;
 		}
 
 		const TArray<TSharedPtr<FJsonValue>>* ContentArray;
@@ -960,23 +957,34 @@ void FClaudeCodeRunner::ParseAndEmitNdjsonLine(const FString& JsonLine)
 		UE_LOG(LogUnrealClaude, Log, TEXT("NDJSON Result: subtype=%s, is_error=%d, stop_reason=%s, duration=%.0fms, turns=%.0f, cost=$%.4f, result=%d chars"),
 			*Subtype, bIsError, *StopReason, DurationMs, NumTurns, TotalCostUsd, ResultText.Len());
 
-		// If the result carries a refusal stop_reason, emit a Refusal event first
+		// If the result carries a refusal stop_reason, emit a Refusal event
+		// only if one wasn't already emitted from the assistant message
 		if (StopReason == TEXT("refusal"))
 		{
-			UE_LOG(LogUnrealClaude, Warning, TEXT("NDJSON: Refusal detected in result event (stop_reason=refusal)"));
-
-			if (CurrentConfig.OnStreamEvent.IsBound())
+			if (!bRefusalDetected.Load())
 			{
-				FClaudeStreamEvent RefusalEvent;
-				RefusalEvent.Type = EClaudeStreamEventType::Refusal;
-				RefusalEvent.StopReason = StopReason;
-				RefusalEvent.bIsError = true;
-				RefusalEvent.RawJson = JsonLine;
-				FOnClaudeStreamEvent EventDelegate = CurrentConfig.OnStreamEvent;
-				AsyncTask(ENamedThreads::GameThread, [EventDelegate, RefusalEvent]()
+				UE_LOG(LogUnrealClaude, Warning, TEXT("NDJSON: Refusal detected in result event (stop_reason=refusal)"));
+
+				bRefusalDetected.Store(true);
+				AccumulatedResponseText.Empty();
+
+				if (CurrentConfig.OnStreamEvent.IsBound())
 				{
-					EventDelegate.ExecuteIfBound(RefusalEvent);
-				});
+					FClaudeStreamEvent RefusalEvent;
+					RefusalEvent.Type = EClaudeStreamEventType::Refusal;
+					RefusalEvent.StopReason = StopReason;
+					RefusalEvent.bIsError = true;
+					RefusalEvent.RawJson = JsonLine;
+					FOnClaudeStreamEvent EventDelegate = CurrentConfig.OnStreamEvent;
+					AsyncTask(ENamedThreads::GameThread, [EventDelegate, RefusalEvent]()
+					{
+						EventDelegate.ExecuteIfBound(RefusalEvent);
+					});
+				}
+			}
+			else
+			{
+				UE_LOG(LogUnrealClaude, Log, TEXT("NDJSON: Refusal in result event (already handled from assistant message)"));
 			}
 		}
 
@@ -1022,6 +1030,7 @@ bool FClaudeCodeRunner::Init()
 {
 	// bIsExecuting is already set by ExecuteAsync (thread-safe)
 	StopTaskCounter.Reset();
+	bRefusalDetected.Store(false);
 	NdjsonLineBuffer.Empty();
 	AccumulatedResponseText.Empty();
 	return true;
@@ -1327,7 +1336,8 @@ void FClaudeCodeRunner::ExecuteProcess()
 	FPlatformProcess::CloseProc(ProcessHandle);
 
 	// Report completion with parsed response text
-	bool bSuccess = (ExitCode == 0) && !StopTaskCounter.GetValue();
+	// A refusal is treated as a failure to prevent the refused exchange from being saved
+	bool bSuccess = (ExitCode == 0) && !StopTaskCounter.GetValue() && !bRefusalDetected.Load();
 	ReportCompletion(ResponseText, bSuccess);
 }
 

--- a/UnrealClaude/Source/UnrealClaude/Private/ClaudeCodeRunner.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ClaudeCodeRunner.cpp
@@ -582,6 +582,42 @@ FString FClaudeCodeRunner::ParseStreamJsonOutput(const FString& RawOutput)
 		}
 	}
 
+	// Check for refusal in assistant messages
+	for (const FString& Line : Lines)
+	{
+		if (Line.IsEmpty())
+		{
+			continue;
+		}
+
+		TSharedPtr<FJsonObject> JsonObj;
+		TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Line);
+		if (!FJsonSerializer::Deserialize(Reader, JsonObj) || !JsonObj.IsValid())
+		{
+			continue;
+		}
+
+		FString Type;
+		if (!JsonObj->TryGetStringField(TEXT("type"), Type))
+		{
+			continue;
+		}
+
+		if (Type == TEXT("assistant"))
+		{
+			const TSharedPtr<FJsonObject>* MessageObj;
+			if (JsonObj->TryGetObjectField(TEXT("message"), MessageObj))
+			{
+				FString StopReason;
+				if ((*MessageObj)->TryGetStringField(TEXT("stop_reason"), StopReason) && StopReason == TEXT("refusal"))
+				{
+					UE_LOG(LogUnrealClaude, Warning, TEXT("ParseStreamJsonOutput: Detected refusal (stop_reason=refusal)"));
+					return TEXT("Error: Response refused by content safety filter. Please rephrase your request.");
+				}
+			}
+		}
+	}
+
 	// Fallback: accumulate text from assistant content blocks
 	FString AccumulatedText;
 	for (const FString& Line : Lines)
@@ -700,6 +736,28 @@ void FClaudeCodeRunner::ParseAndEmitNdjsonLine(const FString& JsonLine)
 		{
 			UE_LOG(LogUnrealClaude, Warning, TEXT("NDJSON: assistant message missing 'message' field"));
 			return;
+		}
+
+		// Check for stop_reason: "refusal" - streaming classifiers intervened
+		FString StopReason;
+		(*MessageObj)->TryGetStringField(TEXT("stop_reason"), StopReason);
+		if (StopReason == TEXT("refusal"))
+		{
+			UE_LOG(LogUnrealClaude, Warning, TEXT("NDJSON: Streaming refusal detected (stop_reason=refusal)"));
+
+			if (CurrentConfig.OnStreamEvent.IsBound())
+			{
+				FClaudeStreamEvent Event;
+				Event.Type = EClaudeStreamEventType::Refusal;
+				Event.StopReason = StopReason;
+				Event.bIsError = true;
+				Event.RawJson = JsonLine;
+				FOnClaudeStreamEvent EventDelegate = CurrentConfig.OnStreamEvent;
+				AsyncTask(ENamedThreads::GameThread, [EventDelegate, Event]()
+				{
+					EventDelegate.ExecuteIfBound(Event);
+				});
+			}
 		}
 
 		const TArray<TSharedPtr<FJsonValue>>* ContentArray;
@@ -895,14 +953,39 @@ void FClaudeCodeRunner::ParseAndEmitNdjsonLine(const FString& JsonLine)
 		double TotalCostUsd = 0.0;
 		JsonObj->TryGetNumberField(TEXT("total_cost_usd"), TotalCostUsd);
 
-		UE_LOG(LogUnrealClaude, Log, TEXT("NDJSON Result: subtype=%s, is_error=%d, duration=%.0fms, turns=%.0f, cost=$%.4f, result=%d chars"),
-			*Subtype, bIsError, DurationMs, NumTurns, TotalCostUsd, ResultText.Len());
+		// Check for stop_reason in the result event
+		FString StopReason;
+		JsonObj->TryGetStringField(TEXT("stop_reason"), StopReason);
+
+		UE_LOG(LogUnrealClaude, Log, TEXT("NDJSON Result: subtype=%s, is_error=%d, stop_reason=%s, duration=%.0fms, turns=%.0f, cost=$%.4f, result=%d chars"),
+			*Subtype, bIsError, *StopReason, DurationMs, NumTurns, TotalCostUsd, ResultText.Len());
+
+		// If the result carries a refusal stop_reason, emit a Refusal event first
+		if (StopReason == TEXT("refusal"))
+		{
+			UE_LOG(LogUnrealClaude, Warning, TEXT("NDJSON: Refusal detected in result event (stop_reason=refusal)"));
+
+			if (CurrentConfig.OnStreamEvent.IsBound())
+			{
+				FClaudeStreamEvent RefusalEvent;
+				RefusalEvent.Type = EClaudeStreamEventType::Refusal;
+				RefusalEvent.StopReason = StopReason;
+				RefusalEvent.bIsError = true;
+				RefusalEvent.RawJson = JsonLine;
+				FOnClaudeStreamEvent EventDelegate = CurrentConfig.OnStreamEvent;
+				AsyncTask(ENamedThreads::GameThread, [EventDelegate, RefusalEvent]()
+				{
+					EventDelegate.ExecuteIfBound(RefusalEvent);
+				});
+			}
+		}
 
 		if (CurrentConfig.OnStreamEvent.IsBound())
 		{
 			FClaudeStreamEvent Event;
 			Event.Type = EClaudeStreamEventType::Result;
 			Event.ResultText = ResultText;
+			Event.StopReason = StopReason;
 			Event.bIsError = bIsError;
 			Event.DurationMs = static_cast<int32>(DurationMs);
 			Event.NumTurns = static_cast<int32>(NumTurns);

--- a/UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp
@@ -427,7 +427,13 @@ void SClaudeEditorWidget::OnClaudeResponse(const FString& Response, bool bSucces
 	else
 	{
 		FinalizeStreamingResponse();
-		AddMessage(FString::Printf(TEXT("Error: %s"), *Response), false);
+		// Only show error message if there's actual error text to display.
+		// Refusals produce an empty response (AccumulatedResponseText was cleared)
+		// and already show a banner via HandleRefusalEvent, so skip the redundant message.
+		if (!Response.IsEmpty())
+		{
+			AddMessage(FString::Printf(TEXT("Error: %s"), *Response), false);
+		}
 	}
 
 	// Clear streaming state

--- a/UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp
@@ -1074,7 +1074,7 @@ void SClaudeEditorWidget::HandleRefusalEvent(const FClaudeStreamEvent& Event)
 	}
 
 	// Display a refusal notice in the streaming content box
-	FString RefusalMessage = TEXT("Response refused by content safety filter. The conversation context has been reset.");
+	FString RefusalMessage = TEXT("Response refused by content safety filter. Please rephrase your request.");
 
 	StreamingContentBox->AddSlot()
 	.AutoHeight()
@@ -1093,8 +1093,9 @@ void SClaudeEditorWidget::HandleRefusalEvent(const FClaudeStreamEvent& Event)
 		]
 	];
 
-	// Reset conversation context as required by the API docs
-	FClaudeCodeSubsystem::Get().ClearHistory();
+	// The refused turn is prevented from being saved to history because
+	// bRefusalDetected causes bSuccess=false in the completion callback,
+	// which skips AddExchange. No need to clear prior valid history.
 
 	if (ChatScrollBox.IsValid())
 	{

--- a/UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp
@@ -745,6 +745,11 @@ void SClaudeEditorWidget::OnClaudeStreamEvent(const FClaudeStreamEvent& Event)
 		HandleResultEvent(Event);
 		break;
 
+	case EClaudeStreamEventType::Refusal:
+		UE_LOG(LogUnrealClaude, Warning, TEXT("[StreamEvent] Refusal: stop_reason=%s"), *Event.StopReason);
+		HandleRefusalEvent(Event);
+		break;
+
 	default:
 		UE_LOG(LogUnrealClaude, Log, TEXT("[StreamEvent] Unknown type: %d"), static_cast<int32>(Event.Type));
 		break;
@@ -1054,6 +1059,42 @@ void SClaudeEditorWidget::HandleResultEvent(const FClaudeStreamEvent& Event)
 		.TextStyle(FAppStyle::Get(), "SmallText")
 		.ColorAndOpacity(FSlateColor(FLinearColor(0.4f, 0.4f, 0.45f)))
 	];
+
+	if (ChatScrollBox.IsValid())
+	{
+		ChatScrollBox->ScrollToEnd();
+	}
+}
+
+void SClaudeEditorWidget::HandleRefusalEvent(const FClaudeStreamEvent& Event)
+{
+	if (!StreamingContentBox.IsValid())
+	{
+		return;
+	}
+
+	// Display a refusal notice in the streaming content box
+	FString RefusalMessage = TEXT("Response refused by content safety filter. The conversation context has been reset.");
+
+	StreamingContentBox->AddSlot()
+	.AutoHeight()
+	.Padding(0, 8, 0, 4)
+	[
+		SNew(SBorder)
+		.BorderImage(FAppStyle::GetBrush("ToolPanel.DarkGroupBorder"))
+		.BorderBackgroundColor(FLinearColor(0.3f, 0.08f, 0.08f, 1.0f))
+		.Padding(FMargin(10.0f, 8.0f))
+		[
+			SNew(STextBlock)
+			.Text(FText::FromString(RefusalMessage))
+			.TextStyle(FAppStyle::Get(), "SmallText")
+			.ColorAndOpacity(FSlateColor(FLinearColor(1.0f, 0.5f, 0.5f)))
+			.AutoWrapText(true)
+		]
+	];
+
+	// Reset conversation context as required by the API docs
+	FClaudeCodeSubsystem::Get().ClearHistory();
 
 	if (ChatScrollBox.IsValid())
 	{

--- a/UnrealClaude/Source/UnrealClaude/Private/ClaudeSessionManager.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ClaudeSessionManager.cpp
@@ -29,6 +29,16 @@ void FClaudeSessionManager::ClearHistory()
 	ConversationHistory.Empty();
 }
 
+void FClaudeSessionManager::DeleteSessionFile()
+{
+	FString SessionPath = GetSessionFilePath();
+	if (IFileManager::Get().FileExists(*SessionPath))
+	{
+		IFileManager::Get().Delete(*SessionPath);
+		UE_LOG(LogUnrealClaude, Log, TEXT("Session file deleted: %s"), *SessionPath);
+	}
+}
+
 FString FClaudeSessionManager::GetSessionFilePath() const
 {
 	FString SaveDir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("UnrealClaude"));

--- a/UnrealClaude/Source/UnrealClaude/Private/ClaudeSubsystem.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ClaudeSubsystem.cpp
@@ -194,6 +194,15 @@ void FClaudeCodeSubsystem::ClearHistory()
 	}
 }
 
+void FClaudeCodeSubsystem::ResetSession()
+{
+	if (SessionManager.IsValid())
+	{
+		SessionManager->ClearHistory();
+		SessionManager->DeleteSessionFile();
+	}
+}
+
 void FClaudeCodeSubsystem::CancelCurrentRequest()
 {
 	if (Runner.IsValid())

--- a/UnrealClaude/Source/UnrealClaude/Public/ClaudeCodeRunner.h
+++ b/UnrealClaude/Source/UnrealClaude/Public/ClaudeCodeRunner.h
@@ -85,6 +85,13 @@ private:
 	FRunnableThread* Thread;
 	FThreadSafeCounter StopTaskCounter;
 	TAtomic<bool> bIsExecuting;
+	TAtomic<bool> bRefusalDetected{false};
+
+public:
+	/** Check if the last execution was refused by streaming safety classifiers */
+	bool WasRefused() const { return bRefusalDetected.Load(); }
+
+private:
 
 	// Process handle (FProcHandle stored as void* for atomic exchange compatibility)
 	FProcHandle ProcessHandle;

--- a/UnrealClaude/Source/UnrealClaude/Public/ClaudeEditorWidget.h
+++ b/UnrealClaude/Source/UnrealClaude/Public/ClaudeEditorWidget.h
@@ -194,6 +194,9 @@ private:
 	/** Handle a Result stream event (append stats footer) */
 	void HandleResultEvent(const FClaudeStreamEvent& Event);
 
+	/** Handle a Refusal stream event (display refusal message, reset context) */
+	void HandleRefusalEvent(const FClaudeStreamEvent& Event);
+
 	/** Update tool group summary text based on pending/completed state */
 	void UpdateToolGroupSummary();
 

--- a/UnrealClaude/Source/UnrealClaude/Public/ClaudeSessionManager.h
+++ b/UnrealClaude/Source/UnrealClaude/Public/ClaudeSessionManager.h
@@ -22,6 +22,9 @@ public:
 	/** Clear conversation history (in memory only) */
 	void ClearHistory();
 
+	/** Delete the session file from disk */
+	void DeleteSessionFile();
+
 	/** Save current session to disk */
 	bool SaveSession();
 

--- a/UnrealClaude/Source/UnrealClaude/Public/ClaudeSubsystem.h
+++ b/UnrealClaude/Source/UnrealClaude/Public/ClaudeSubsystem.h
@@ -83,6 +83,9 @@ public:
 	/** Clear conversation history */
 	void ClearHistory();
 
+	/** Reset session completely (clear in-memory history and delete session file from disk) */
+	void ResetSession();
+
 	/** Cancel current request */
 	void CancelCurrentRequest();
 

--- a/UnrealClaude/Source/UnrealClaude/Public/IClaudeRunner.h
+++ b/UnrealClaude/Source/UnrealClaude/Public/IClaudeRunner.h
@@ -24,6 +24,8 @@ enum class EClaudeStreamEventType : uint8
 	ToolResult,
 	/** Final result with stats and cost */
 	Result,
+	/** Streaming refusal - response was refused by safety classifiers */
+	Refusal,
 	/** Raw assistant message (full message, not parsed into sub-events) */
 	AssistantMessage,
 	/** Unknown or unparsed event type */
@@ -56,6 +58,9 @@ struct UNREALCLAUDE_API FClaudeStreamEvent
 
 	/** Session ID (for SessionInit/Result events) */
 	FString SessionId;
+
+	/** Stop reason from the API (e.g., "end_turn", "refusal", "tool_use") */
+	FString StopReason;
 
 	/** Whether this is an error event */
 	bool bIsError = false;


### PR DESCRIPTION
Detect and handle the new stop_reason: "refusal" from Claude's streaming
API when safety classifiers intervene. Adds Refusal event type, parses
stop_reason from assistant and result NDJSON events, displays a styled
notice in the chat UI, and auto-resets conversation context to prevent
continued refusals.

https://claude.ai/code/session_019zGWwERHUy6HGqSyDj72Hc