### PR TITLE
fix: resolve enum variable type displayed as byte in blueprint inspection

### DIFF
--- a/UnrealClaude/Source/UnrealClaude/Private/BlueprintEditor.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/BlueprintEditor.cpp
@@ -492,7 +492,15 @@ FString FBlueprintEditor::PinTypeToString(const FEdGraphPinType& PinType)
 	}
 	else if (PinType.PinCategory == UEdGraphSchema_K2::PC_Byte)
 	{
-		TypeName = TEXT("byte");
+		// FByteProperty with a non-null Enum pointer means a UENUM variable; prefer enum name over "byte"
+		if (UEnum* Enum = Cast<UEnum>(PinType.PinSubCategoryObject.Get()))
+		{
+			TypeName = Enum->GetName();
+		}
+		else
+		{
+			TypeName = TEXT("byte");
+		}
 	}
 	else if (PinType.PinCategory == UEdGraphSchema_K2::PC_String)
 	{


### PR DESCRIPTION
Please find a proposal for my issue #29 

## Summary

- Blueprint variables typed as a custom UENUM were reported as `byte` instead of the actual enum name in the output of `blueprint_query`.
- `PinTypeToString` now checks `PinSubCategoryObject` for a `UEnum*` when the pin category is `PC_Byte`, and returns the enum class name when found.
- Plain `uint8` variables (no associated enum) are unaffected and still report as `byte`.

## Root Cause

`BlueprintEditor.cpp` — `PinTypeToString()`: the `PC_Byte` branch unconditionally returned `"byte"`, ignoring the `PinType.PinSubCategoryObject` pointer that UE sets to the `UEnum` object for enum-typed variables. The fix mirrors the existing pattern already used for `PC_Struct` and `PC_Object`.