### PR TITLE
Support Markdown display and optimized some user experience

### DIFF
--- a/UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp
@@ -10,6 +10,7 @@
 #include "MCP/MCPToolRegistry.h"
 #include "Widgets/SClaudeToolbar.h"
 #include "Widgets/SClaudeInputArea.h"
+#include "Widgets/SMarkdownWidget.h"
 
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/Layout/SBorder.h"
@@ -30,6 +31,90 @@
 #define LOCTEXT_NAMESPACE "UnrealClaude"
 
 // ============================================================================
+// SRightClickDragBox
+// ============================================================================
+
+void SRightClickDragBox::Construct(const FArguments& InArgs)
+{
+	TargetScrollBox = InArgs._ScrollBox;
+
+	ChildSlot
+	[
+		InArgs._Content.Widget
+	];
+}
+
+FReply SRightClickDragBox::OnMouseButtonDown(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent)
+{
+	if (MouseEvent.GetEffectingButton() == EKeys::RightMouseButton)
+	{
+		bIsDragging = true;
+		DragStartMousePos = MouseEvent.GetScreenSpacePosition();
+
+		if (TargetScrollBox.IsValid())
+		{
+			DragStartScrollOffset = TargetScrollBox->GetScrollOffset();
+		}
+
+		return FReply::Handled().CaptureMouse(SharedThis(this));
+	}
+
+	return FReply::Unhandled();
+}
+
+FReply SRightClickDragBox::OnMouseButtonUp(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent)
+{
+	if (MouseEvent.GetEffectingButton() == EKeys::RightMouseButton && bIsDragging)
+	{
+		bIsDragging = false;
+		return FReply::Handled().ReleaseMouseCapture();
+	}
+
+	return FReply::Unhandled();
+}
+
+FReply SRightClickDragBox::OnMouseMove(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent)
+{
+	if (bIsDragging && TargetScrollBox.IsValid())
+	{
+		FVector2D CurrentMousePos = MouseEvent.GetScreenSpacePosition();
+		float DeltaY = DragStartMousePos.Y - CurrentMousePos.Y;
+
+		// Apply delta to scroll offset (moving mouse up scrolls content down, moving down scrolls content up)
+		float NewScrollOffset = DragStartScrollOffset + DeltaY;
+		TargetScrollBox->SetScrollOffset(NewScrollOffset);
+
+		return FReply::Handled();
+	}
+
+	return FReply::Unhandled();
+}
+
+TOptional<EMouseCursor::Type> SRightClickDragBox::GetCursor() const
+{
+	if (bIsDragging)
+	{
+		return EMouseCursor::GrabHandClosed;
+	}
+	return TOptional<EMouseCursor::Type>();
+}
+
+FReply SRightClickDragBox::OnMouseWheel(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent)
+{
+	if (TargetScrollBox.IsValid())
+	{
+		// Forward wheel event to scroll box
+		float CurrentOffset = TargetScrollBox->GetScrollOffset();
+		float WheelDelta = MouseEvent.GetWheelDelta();
+		float ScrollSpeed = 50.0f; // Pixels per wheel tick
+		float NewOffset = CurrentOffset - (WheelDelta * ScrollSpeed);
+		TargetScrollBox->SetScrollOffset(NewOffset);
+		return FReply::Handled();
+	}
+	return FReply::Unhandled();
+}
+
+// ============================================================================
 // SChatMessage
 // ============================================================================
 
@@ -37,6 +122,8 @@ void SChatMessage::Construct(const FArguments& InArgs)
 {
 	bool bIsUser = InArgs._IsUser;
 	FString Message = InArgs._Message;
+	bUseMarkdown = InArgs._bRenderMarkdown && !bIsUser;  // Only render Markdown for Claude messages
+	bSelectionModeAttr = InArgs._bSelectionMode;
 
 	// Distinct colors for user vs assistant
 	FLinearColor BackgroundColor = bIsUser
@@ -54,6 +141,25 @@ void SChatMessage::Construct(const FArguments& InArgs)
 		: FLinearColor(0.9f, 0.6f, 0.3f);  // Warm orange
 
 	FString RoleLabel = bIsUser ? TEXT("> You") : TEXT("Claude");
+
+	// Build content widget - use Markdown for Claude, plain text for user
+	TSharedPtr<SWidget> ContentWidget;
+	if (bUseMarkdown)
+	{
+		SAssignNew(MarkdownWidget, SMarkdownWidget)
+			.Text(Message)
+			.bDarkTheme(true)
+			.bSelectionMode_Lambda([this]() { return bSelectionModeAttr.Get(); });
+		ContentWidget = MarkdownWidget;
+	}
+	else
+	{
+		ContentWidget = SNew(STextBlock)
+			.Text(FText::FromString(Message))
+			.TextStyle(FAppStyle::Get(), "NormalText")
+			.ColorAndOpacity(FSlateColor(TextColor))
+			.AutoWrapText(true);
+	}
 
 	ChildSlot
 	[
@@ -94,15 +200,11 @@ void SChatMessage::Construct(const FArguments& InArgs)
 					.ColorAndOpacity(FSlateColor(RoleLabelColor))
 				]
 
-				// Message content
+				// Message content (Markdown or plain text)
 				+ SVerticalBox::Slot()
 				.AutoHeight()
 				[
-					SNew(STextBlock)
-					.Text(FText::FromString(Message))
-					.TextStyle(FAppStyle::Get(), "NormalText")
-					.ColorAndOpacity(FSlateColor(TextColor))
-					.AutoWrapText(true)
+					ContentWidget.ToSharedRef()
 				]
 			]
 		]
@@ -192,8 +294,14 @@ TSharedRef<SWidget> SClaudeEditorWidget::BuildToolbar()
 		.bUE57ContextEnabled_Lambda([this]() { return bIncludeUE57Context; })
 		.bProjectContextEnabled_Lambda([this]() { return bIncludeProjectContext; })
 		.bRestoreEnabled_Lambda([this]() { return FClaudeCodeSubsystem::Get().HasSavedSession(); })
+		.bSelectionMode_Lambda([this]() { return bSelectionMode; })
 		.OnUE57ContextChanged_Lambda([this](bool bEnabled) { bIncludeUE57Context = bEnabled; })
 		.OnProjectContextChanged_Lambda([this](bool bEnabled) { bIncludeProjectContext = bEnabled; })
+		.OnSelectionModeChanged_Lambda([this](bool bEnabled) {
+				bSelectionMode = bEnabled;
+				// Invalidate the widget to force re-evaluation of dynamic attributes
+				Invalidate(EInvalidateWidgetReason::Layout);
+			})
 		.OnRefreshContext_Lambda([this]() { RefreshProjectContext(); })
 		.OnRestoreSession_Lambda([this]() { RestoreSession(); })
 		.OnNewSession_Lambda([this]() { NewSession(); })
@@ -203,14 +311,23 @@ TSharedRef<SWidget> SClaudeEditorWidget::BuildToolbar()
 
 TSharedRef<SWidget> SClaudeEditorWidget::BuildChatArea()
 {
+	// Create the scroll box
+	TSharedRef<SScrollBox> ScrollBoxRef = SNew(SScrollBox)
+		+ SScrollBox::Slot()
+		[
+			SAssignNew(ChatMessagesBox, SVerticalBox)
+		];
+	ChatScrollBox = ScrollBoxRef;
+
+	// Wrap in border with right-click drag box as parent of scroll box
 	return SNew(SBorder)
 		.BorderImage(FAppStyle::GetBrush("ToolPanel.DarkGroupBorder"))
 		.Padding(4.0f)
 		[
-			SAssignNew(ChatScrollBox, SScrollBox)
-			+ SScrollBox::Slot()
+			SNew(SRightClickDragBox)
+			.ScrollBox(ChatScrollBox)
 			[
-				SAssignNew(ChatMessagesBox, SVerticalBox)
+				ScrollBoxRef
 			]
 		];
 }
@@ -279,8 +396,14 @@ TSharedRef<SWidget> SClaudeEditorWidget::BuildStatusBar()
 
 void SClaudeEditorWidget::AddMessage(const FString& Message, bool bIsUser)
 {
+	// Store message for rebuilding
+	MessageHistory.Add(TPair<FString, bool>(Message, bIsUser));
+
 	if (ChatMessagesBox.IsValid())
 	{
+		// Check if we're at bottom before adding content
+		bool bWasAtBottom = IsScrolledToBottom();
+
 		// Add a thin separator line between messages for visual clarity
 		if (ChatMessagesBox->NumSlots() > 0)
 		{
@@ -300,13 +423,65 @@ void SClaudeEditorWidget::AddMessage(const FString& Message, bool bIsUser)
 			SNew(SChatMessage)
 			.Message(Message)
 			.IsUser(bIsUser)
+			.bRenderMarkdown(!bIsUser)  // Enable Markdown rendering for Claude messages
+			.bSelectionMode_Lambda([this, bIsUser]() { return bSelectionMode && !bIsUser; })  // Dynamic: only for Claude messages
 		];
 
-		// Scroll to bottom
-		if (ChatScrollBox.IsValid())
+		// Only scroll to bottom if we were already there
+		if (bWasAtBottom)
 		{
-			ChatScrollBox->ScrollToEnd();
+			ScrollToEnd();
 		}
+	}
+}
+
+void SClaudeEditorWidget::RebuildChatMessages()
+{
+	if (!ChatMessagesBox.IsValid())
+	{
+		return;
+	}
+
+	// Check if we're at bottom before rebuilding
+	bool bWasAtBottom = IsScrolledToBottom();
+
+	// Clear existing messages
+	ChatMessagesBox->ClearChildren();
+
+	// Rebuild all messages with current selection mode
+	for (int32 i = 0; i < MessageHistory.Num(); ++i)
+	{
+		const FString& Message = MessageHistory[i].Key;
+		bool bIsUser = MessageHistory[i].Value;
+
+		// Add separator between messages
+		if (i > 0)
+		{
+			ChatMessagesBox->AddSlot()
+			.AutoHeight()
+			.Padding(FMargin(8.0f, 2.0f))
+			[
+				SNew(SSeparator)
+				.ColorAndOpacity(FLinearColor(0.15f, 0.15f, 0.15f, 0.5f))
+			];
+		}
+
+		ChatMessagesBox->AddSlot()
+		.AutoHeight()
+		.Padding(FMargin(4.0f, 6.0f, 4.0f, 6.0f))
+		[
+			SNew(SChatMessage)
+			.Message(Message)
+			.IsUser(bIsUser)
+			.bRenderMarkdown(!bIsUser)
+			.bSelectionMode_Lambda([this, bIsUser]() { return bSelectionMode && !bIsUser; })
+		];
+	}
+
+	// Only scroll to bottom if we were already there
+	if (bWasAtBottom)
+	{
+		ScrollToEnd();
 	}
 }
 
@@ -447,6 +622,7 @@ void SClaudeEditorWidget::ClearChat()
 		ChatMessagesBox->ClearChildren();
 	}
 
+	MessageHistory.Empty();
 	FClaudeCodeSubsystem::Get().ClearHistory();
 	LastResponse.Empty();
 	ResetStreamingState();
@@ -516,6 +692,8 @@ void SClaudeEditorWidget::NewSession()
 	{
 		ChatMessagesBox->ClearChildren();
 	}
+
+	MessageHistory.Empty();
 
 	// Clear the subsystem history
 	FClaudeCodeSubsystem::Get().ClearHistory();
@@ -708,34 +886,33 @@ void SClaudeEditorWidget::StartStreamingResponse()
 				]
 			]
 		];
+		}
 
-		// Scroll to bottom
-		if (ChatScrollBox.IsValid())
+		// Scroll to bottom to show the new streaming response
+		ScrollToEnd();
+	}
+
+	void SClaudeEditorWidget::OnClaudeProgress(const FString& PartialOutput)
+	{
+		// Check if user was at bottom before this update
+		bool bWasAtBottom = IsScrolledToBottom();
+
+		// Append to total and current segment
+		StreamingResponse += PartialOutput;
+		CurrentSegmentText += PartialOutput;
+
+		// Update the current text segment block
+		if (StreamingTextBlock.IsValid())
 		{
-			ChatScrollBox->ScrollToEnd();
+			StreamingTextBlock->SetText(FText::FromString(CurrentSegmentText));
+		}
+
+		// Scroll to bottom only if user was already there before content grew
+		if (bWasAtBottom)
+		{
+			ScrollToEnd();
 		}
 	}
-}
-
-void SClaudeEditorWidget::OnClaudeProgress(const FString& PartialOutput)
-{
-	// Append to total and current segment
-	StreamingResponse += PartialOutput;
-	CurrentSegmentText += PartialOutput;
-
-	// Update the current text segment block
-	if (StreamingTextBlock.IsValid())
-	{
-		StreamingTextBlock->SetText(FText::FromString(CurrentSegmentText));
-	}
-
-	// Auto-scroll to bottom as content streams in
-	if (ChatScrollBox.IsValid())
-	{
-		ChatScrollBox->ScrollToEnd();
-	}
-}
-
 void SClaudeEditorWidget::OnClaudeStreamEvent(const FClaudeStreamEvent& Event)
 {
 	switch (Event.Type)
@@ -781,6 +958,8 @@ void SClaudeEditorWidget::FinalizeStreamingResponse()
 	// Save the final text segment
 	AllTextSegments.Add(CurrentSegmentText);
 
+	LastResponse = StreamingResponse.IsEmpty() ? CurrentSegmentText : StreamingResponse;
+
 	// Rebuild StreamingResponse from all segments for copy support
 	FString Rebuilt;
 	for (const FString& Segment : AllTextSegments)
@@ -790,18 +969,31 @@ void SClaudeEditorWidget::FinalizeStreamingResponse()
 	if (!Rebuilt.IsEmpty())
 	{
 		StreamingResponse = Rebuilt;
+		LastResponse = StreamingResponse;
 	}
 
-	// For simple single-segment responses (no tool events), ensure text block is up to date
-	if (StreamingTextBlock.IsValid() && !StreamingResponse.IsEmpty() && TextSegmentBlocks.Num() <= 1)
+	// Render each text segment in its corresponding container
+	// This ensures text appears before/after tools in the correct order
+	for (int32 i = 0; i < TextSegmentContainers.Num() && i < AllTextSegments.Num(); ++i)
 	{
-		StreamingTextBlock->SetText(FText::FromString(StreamingResponse));
+		if (TextSegmentContainers[i].IsValid() && !AllTextSegments[i].IsEmpty())
+		{
+			TextSegmentContainers[i]->ClearChildren();
+			TextSegmentContainers[i]->AddSlot()
+			.AutoHeight()
+			[
+				SNew(SMarkdownWidget)
+				.Text(AllTextSegments[i])
+				.bDarkTheme(true)
+				.bSelectionMode_Lambda([this]() { return bSelectionMode; })
+			];
+		}
+		else if (TextSegmentContainers[i].IsValid() && AllTextSegments[i].IsEmpty())
+		{
+			// Collapse empty text segments
+			TextSegmentContainers[i]->SetVisibility(EVisibility::Collapsed);
+		}
 	}
-
-	LastResponse = StreamingResponse;
-
-	// Post-process text segments to render code blocks
-	ParseAndRenderCodeBlocks();
 
 	// Clear all streaming state (except StreamingResponse which is used by OnClaudeResponse)
 	StreamingTextBlock.Reset();
@@ -989,12 +1181,7 @@ void SClaudeEditorWidget::HandleToolUseEvent(const FClaudeStreamEvent& Event)
 	// Update group summary header
 	UpdateToolGroupSummary();
 
-	if (ChatScrollBox.IsValid())
-	{
-		ChatScrollBox->ScrollToEnd();
-	}
 }
-
 void SClaudeEditorWidget::HandleToolResultEvent(const FClaudeStreamEvent& Event)
 {
 	// Look up tool name
@@ -1028,15 +1215,11 @@ void SClaudeEditorWidget::HandleToolResultEvent(const FClaudeStreamEvent& Event)
 		(*ExpandPtr)->SetVisibility(EVisibility::Visible);
 	}
 
-	// Update group summary
+	// Update completion tracking
 	ToolGroupDoneCount++;
 	UpdateToolGroupSummary();
-
-	if (ChatScrollBox.IsValid())
-	{
-		ChatScrollBox->ScrollToEnd();
 	}
-}
+
 
 void SClaudeEditorWidget::HandleResultEvent(const FClaudeStreamEvent& Event)
 {
@@ -1079,11 +1262,6 @@ void SClaudeEditorWidget::HandleResultEvent(const FClaudeStreamEvent& Event)
 		.TextStyle(FAppStyle::Get(), "SmallText")
 		.ColorAndOpacity(FSlateColor(FLinearColor(0.4f, 0.4f, 0.45f)))
 	];
-
-	if (ChatScrollBox.IsValid())
-	{
-		ChatScrollBox->ScrollToEnd();
-	}
 }
 
 void SClaudeEditorWidget::HandleRefusalEvent(const FClaudeStreamEvent& Event)
@@ -1112,15 +1290,6 @@ void SClaudeEditorWidget::HandleRefusalEvent(const FClaudeStreamEvent& Event)
 			.AutoWrapText(true)
 		]
 	];
-
-	// The refused turn is prevented from being saved to history because
-	// bRefusalDetected causes bSuccess=false in the completion callback,
-	// which skips AddExchange. No need to clear prior valid history.
-
-	if (ChatScrollBox.IsValid())
-	{
-		ChatScrollBox->ScrollToEnd();
-	}
 }
 
 FString SClaudeEditorWidget::GetDisplayToolName(const FString& FullToolName)
@@ -1446,6 +1615,29 @@ FString SClaudeEditorWidget::GenerateMCPStatusMessage() const
 	StatusMessage += TEXT("─────────────────────────────────");
 
 	return StatusMessage;
+}
+
+bool SClaudeEditorWidget::IsScrolledToBottom() const
+{
+	if (!ChatScrollBox.IsValid())
+	{
+		return true;  // Default to true so initial messages scroll to bottom
+	}
+
+	float CurrentOffset = ChatScrollBox->GetScrollOffset();
+	float EndOffset = ChatScrollBox->GetScrollOffsetOfEnd();
+
+	// EndOffset is the scroll position where bottom of content is visible
+	// Consider "at bottom" if within 50 pixels of the end
+	return (EndOffset - CurrentOffset) <= 50.0f;
+}
+
+void SClaudeEditorWidget::ScrollToEnd()
+{
+	if (ChatScrollBox.IsValid())
+	{
+		ChatScrollBox->ScrollToEnd();
+	}
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/UnrealClaude/Source/UnrealClaude/Private/Widgets/SClaudeInputArea.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/Widgets/SClaudeInputArea.cpp
@@ -4,6 +4,7 @@
 #include "ClipboardImageUtils.h"
 #include "UnrealClaudeConstants.h"
 #include "UnrealClaudeModule.h"
+#include "Framework/Application/SlateApplication.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SMultiLineEditableTextBox.h"
 #include "Widgets/Images/SImage.h"
@@ -16,6 +17,7 @@
 #include "Styling/AppStyle.h"
 #include "Brushes/SlateDynamicImageBrush.h"
 #include "HAL/PlatformApplicationMisc.h"
+#include "HAL/PlatformTime.h"
 #include "Misc/FileHelper.h"
 #include "IImageWrapperModule.h"
 #include "IImageWrapper.h"
@@ -65,9 +67,10 @@ void SClaudeInputArea::Construct(const FArguments& InArgs)
 						.HintText(LOCTEXT("InputHint", "Ask Claude about Unreal Engine 5.7... (Shift+Enter for newline)"))
 						.AutoWrapText(true)
 						.AllowMultiLine(true)
+						.ClearKeyboardFocusOnCommit(false)
+						.ModiferKeyForNewLine(EModifierKey::Shift)
 						.OnTextChanged(this, &SClaudeInputArea::HandleTextChanged)
 						.OnTextCommitted(this, &SClaudeInputArea::HandleTextCommitted)
-						.OnKeyDownHandler(this, &SClaudeInputArea::OnInputKeyDown)
 						.IsEnabled_Lambda([this]() { return !bIsWaiting.Get(); })
 					]
 				]
@@ -81,7 +84,7 @@ void SClaudeInputArea::Construct(const FArguments& InArgs)
 			[
 				SNew(SVerticalBox)
 
-				// Paste from clipboard button
+				// Paste from clipboard button (not focusable to preserve IME state)
 				+ SVerticalBox::Slot()
 				.AutoHeight()
 				.Padding(0.0f, 0.0f, 0.0f, 4.0f)
@@ -91,9 +94,10 @@ void SClaudeInputArea::Construct(const FArguments& InArgs)
 					.OnClicked(this, &SClaudeInputArea::HandlePasteClicked)
 					.ToolTipText(LOCTEXT("PasteTip", "Paste text or image from clipboard"))
 					.IsEnabled_Lambda([this]() { return !bIsWaiting.Get(); })
+					.IsFocusable(false)
 				]
 
-				// Send/Cancel button
+				// Send/Cancel button (not focusable to preserve IME state)
 				+ SVerticalBox::Slot()
 				.AutoHeight()
 				[
@@ -101,6 +105,7 @@ void SClaudeInputArea::Construct(const FArguments& InArgs)
 					.Text_Lambda([this]() { return bIsWaiting.Get() ? LOCTEXT("Cancel", "Cancel") : LOCTEXT("Send", "Send"); })
 					.OnClicked(this, &SClaudeInputArea::HandleSendCancelClicked)
 					.ButtonStyle(FAppStyle::Get(), "PrimaryButton")
+					.IsFocusable(false)
 				]
 			]
 		]
@@ -184,42 +189,45 @@ void SClaudeInputArea::RemoveAttachedImage(int32 Index)
 	}
 }
 
-FReply SClaudeInputArea::OnInputKeyDown(const FGeometry& MyGeometry, const FKeyEvent& InKeyEvent)
+void SClaudeInputArea::SetFocusToInputBox()
 {
-	// Ctrl+V: try image paste first, fall back to text paste
-	if (InKeyEvent.GetKey() == EKeys::V && InKeyEvent.IsControlDown())
+	if (InputTextBox.IsValid())
 	{
-		if (TryPasteImageFromClipboard())
-		{
-			return FReply::Handled();
-		}
-		// Return unhandled to let default text paste proceed
-		return FReply::Unhandled();
+		FSlateApplication::Get().SetUserFocus(0, InputTextBox.ToSharedRef(), EFocusCause::SetDirectly);
 	}
-
-	// Enter (without Shift) to send
-	// Shift+Enter allows newline
-	if (InKeyEvent.GetKey() == EKeys::Enter)
-	{
-		if (!InKeyEvent.IsShiftDown())
-		{
-			OnSend.ExecuteIfBound();
-			return FReply::Handled();
-		}
-	}
-
-	return FReply::Unhandled();
 }
 
 void SClaudeInputArea::HandleTextChanged(const FText& NewText)
 {
 	CurrentInputText = NewText.ToString();
+	LastTextChangeTime = FPlatformTime::Seconds();
 	OnTextChangedDelegate.ExecuteIfBound(CurrentInputText);
 }
 
 void SClaudeInputArea::HandleTextCommitted(const FText& NewText, ETextCommit::Type CommitType)
 {
-	// Don't send on commit - use explicit Enter key handling
+	// Send message when Enter is pressed (OnEnter commit type)
+	// Shift+Enter creates newline and doesn't trigger OnEnter
+	// IME composition confirmation also triggers OnEnter, but it happens immediately after
+	// text change (within ~50ms). Normal typing has a longer gap between text change and Enter.
+	// We detect IME composition by checking if text changed very recently.
+	if (CommitType == ETextCommit::OnEnter)
+	{
+		const double CurrentTime = FPlatformTime::Seconds();
+		const double TimeSinceLastChange = CurrentTime - LastTextChangeTime;
+
+		// If text changed within 100ms, likely IME composition confirmation - don't send
+		if (TimeSinceLastChange < 0.1)
+		{
+			// IME composition confirmation - reset timestamp and don't send
+			LastTextChangeTime = 0.0;
+		}
+		else if (!CurrentInputText.IsEmpty() && !bIsWaiting.Get())
+		{
+			// Normal Enter press - send the message
+			OnSend.ExecuteIfBound();
+		}
+	}
 }
 
 FReply SClaudeInputArea::HandlePasteClicked()
@@ -230,15 +238,14 @@ FReply SClaudeInputArea::HandlePasteClicked()
 		return FReply::Handled();
 	}
 
-	// Fall back to text paste
+	// Simple text paste - use InsertTextAtCursor
 	FString ClipboardText;
 	FPlatformApplicationMisc::ClipboardPaste(ClipboardText);
 	if (!ClipboardText.IsEmpty() && InputTextBox.IsValid())
 	{
-		// Append to existing text
-		FString NewText = CurrentInputText + ClipboardText;
-		SetText(NewText);
+		InputTextBox->InsertTextAtCursor(ClipboardText);
 	}
+
 	return FReply::Handled();
 }
 
@@ -252,6 +259,8 @@ FReply SClaudeInputArea::HandleSendCancelClicked()
 	{
 		OnSend.ExecuteIfBound();
 	}
+
+	// Since button is not focusable, focus stays on text box - no need to restore
 	return FReply::Handled();
 }
 
@@ -360,6 +369,7 @@ void SClaudeInputArea::RebuildImagePreviewStrip()
 					})
 					.ToolTipText(LOCTEXT("RemoveImageTip", "Remove this image"))
 					.ButtonStyle(FAppStyle::Get(), "SimpleButton")
+					.IsFocusable(false)
 				]
 			]
 		];

--- a/UnrealClaude/Source/UnrealClaude/Private/Widgets/SClaudeInputArea.h
+++ b/UnrealClaude/Source/UnrealClaude/Private/Widgets/SClaudeInputArea.h
@@ -58,10 +58,10 @@ public:
 	/** Remove a specific attached image by index */
 	void RemoveAttachedImage(int32 Index);
 
-private:
-	/** Handle key down in input box */
-	FReply OnInputKeyDown(const FGeometry& MyGeometry, const FKeyEvent& InKeyEvent);
+	/** Set focus to the input text box (for IME support) */
+	void SetFocusToInputBox();
 
+private:
 	/** Handle text change */
 	void HandleTextChanged(const FText& NewText);
 
@@ -98,6 +98,9 @@ private:
 
 	/** Dynamic brushes for thumbnails (must outlive the SImage widgets) */
 	TArray<TSharedPtr<FSlateDynamicImageBrush>> ThumbnailBrushes;
+
+	/** Timestamp of last text change (used to detect IME composition confirmation) */
+	double LastTextChangeTime = 0.0;
 
 	TAttribute<bool> bIsWaiting;
 	FOnInputAction OnSend;

--- a/UnrealClaude/Source/UnrealClaude/Private/Widgets/SClaudeToolbar.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/Widgets/SClaudeToolbar.cpp
@@ -16,8 +16,10 @@ void SClaudeToolbar::Construct(const FArguments& InArgs)
 	bUE57ContextEnabled = InArgs._bUE57ContextEnabled;
 	bProjectContextEnabled = InArgs._bProjectContextEnabled;
 	bRestoreEnabled = InArgs._bRestoreEnabled;
+	bSelectionMode = InArgs._bSelectionMode;
 	OnUE57ContextChanged = InArgs._OnUE57ContextChanged;
 	OnProjectContextChanged = InArgs._OnProjectContextChanged;
+	OnSelectionModeChanged = InArgs._OnSelectionModeChanged;
 	OnRefreshContext = InArgs._OnRefreshContext;
 	OnRestoreSession = InArgs._OnRestoreSession;
 	OnNewSession = InArgs._OnNewSession;
@@ -139,6 +141,30 @@ void SClaudeToolbar::Construct(const FArguments& InArgs)
 				.Text(LOCTEXT("Copy", "Copy Last"))
 				.OnClicked_Lambda([this]() { OnCopyLast.ExecuteIfBound(); return FReply::Handled(); })
 				.ToolTipText(LOCTEXT("CopyTip", "Copy last response to clipboard"))
+			]
+
+			// Selection mode toggle button (at the far right)
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(8.0f, 0.0f, 0.0f, 0.0f)
+			[
+				SNew(SButton)
+				.Text_Lambda([this]() {
+					return bSelectionMode.Get()
+						? LOCTEXT("ShowFormatted", "Formatted")
+						: LOCTEXT("ShowSelectText", "Plain Text");
+				})
+				.OnClicked_Lambda([this]() {
+					// Toggle between modes
+					OnSelectionModeChanged.ExecuteIfBound(!bSelectionMode.Get());
+					return FReply::Handled();
+				})
+				.ToolTipText_Lambda([this]() {
+					return bSelectionMode.Get()
+						? LOCTEXT("ShowFormattedTip", "Switch to formatted markdown view")
+						: LOCTEXT("ShowSelectTextTip", "Switch to plain text for easy selection and copying");
+				})
 			]
 		]
 	];

--- a/UnrealClaude/Source/UnrealClaude/Private/Widgets/SClaudeToolbar.h
+++ b/UnrealClaude/Source/UnrealClaude/Private/Widgets/SClaudeToolbar.h
@@ -11,7 +11,7 @@ DECLARE_DELEGATE_OneParam(FOnCheckboxChanged, bool)
 
 /**
  * Toolbar widget for Claude Editor
- * Handles UE context toggles, session management buttons
+ * Handles UE context toggles, session management buttons, and view mode toggle
  */
 class SClaudeToolbar : public SCompoundWidget
 {
@@ -20,12 +20,15 @@ public:
 		: _bUE57ContextEnabled(true)
 		, _bProjectContextEnabled(true)
 		, _bRestoreEnabled(false)
+		, _bSelectionMode(false)
 	{}
 		SLATE_ATTRIBUTE(bool, bUE57ContextEnabled)
 		SLATE_ATTRIBUTE(bool, bProjectContextEnabled)
 		SLATE_ATTRIBUTE(bool, bRestoreEnabled)
+		SLATE_ATTRIBUTE(bool, bSelectionMode)
 		SLATE_EVENT(FOnCheckboxChanged, OnUE57ContextChanged)
 		SLATE_EVENT(FOnCheckboxChanged, OnProjectContextChanged)
+		SLATE_EVENT(FOnCheckboxChanged, OnSelectionModeChanged)
 		SLATE_EVENT(FOnToolbarAction, OnRefreshContext)
 		SLATE_EVENT(FOnToolbarAction, OnRestoreSession)
 		SLATE_EVENT(FOnToolbarAction, OnNewSession)
@@ -39,9 +42,11 @@ private:
 	TAttribute<bool> bUE57ContextEnabled;
 	TAttribute<bool> bProjectContextEnabled;
 	TAttribute<bool> bRestoreEnabled;
+	TAttribute<bool> bSelectionMode;
 
 	FOnCheckboxChanged OnUE57ContextChanged;
 	FOnCheckboxChanged OnProjectContextChanged;
+	FOnCheckboxChanged OnSelectionModeChanged;
 	FOnToolbarAction OnRefreshContext;
 	FOnToolbarAction OnRestoreSession;
 	FOnToolbarAction OnNewSession;

--- a/UnrealClaude/Source/UnrealClaude/Private/Widgets/SMarkdownWidget.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/Widgets/SMarkdownWidget.cpp
@@ -1,0 +1,1513 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#include "SMarkdownWidget.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Text/SRichTextBlock.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Layout/SSpacer.h"
+#include "Widgets/Layout/SWidgetSwitcher.h"
+#include "Widgets/Layout/SWrapBox.h"
+#include "Widgets/Layout/SGridPanel.h"
+#include "Widgets/Input/SHyperlink.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/SNullWidget.h"
+#include "Widgets/Text/SMultiLineEditableText.h"
+#include "Framework/Text/RichTextLayoutMarshaller.h"
+#include "Framework/Text/TextDecorators.h"
+#include "Framework/Text/ITextDecorator.h"
+#include "Framework/Text/SlateTextRun.h"
+#include "Framework/Text/SlateHyperlinkRun.h"
+#include "Styling/AppStyle.h"
+#include "Styling/CoreStyle.h"
+#include "Framework/Application/SlateApplication.h"
+#include "HAL/PlatformApplicationMisc.h"
+
+#define LOCTEXT_NAMESPACE "MarkdownWidget"
+
+// Helper function to check if a character is alphanumeric (word character)
+static bool IsAlphanumeric(TCHAR Ch)
+{
+    return (Ch >= 'a' && Ch <= 'z') ||
+           (Ch >= 'A' && Ch <= 'Z') ||
+           (Ch >= '0' && Ch <= '9');
+}
+
+/**
+ * Simple text decorator that applies a specific font style and color
+ */
+class FStyleTextDecorator : public ITextDecorator
+{
+public:
+    static TSharedRef<FStyleTextDecorator> Create(const FString& InRunName, const FSlateColor& InColor, const FSlateFontInfo& InFont)
+    {
+        return MakeShareable(new FStyleTextDecorator(InRunName, InColor, InFont));
+    }
+
+    virtual ~FStyleTextDecorator() {}
+
+    virtual bool Supports(const FTextRunParseResults& RunParseResult, const FString& Text) const override
+    {
+        return RunParseResult.Name == RunName;
+    }
+
+    virtual TSharedRef<ISlateRun> Create(
+        const TSharedRef<class FTextLayout>& TextLayout,
+        const FTextRunParseResults& RunParseResult,
+        const FString& OriginalText,
+        const TSharedRef<FString>& InOutModelText,
+        const ISlateStyle* Style) override
+    {
+        FRunInfo RunInfo(RunParseResult.Name);
+        for (const TPair<FString, FTextRange>& Pair : RunParseResult.MetaData)
+        {
+            RunInfo.MetaData.Add(Pair.Key, OriginalText.Mid(Pair.Value.BeginIndex, Pair.Value.EndIndex - Pair.Value.BeginIndex));
+        }
+
+        const FTextRange ModelRange(InOutModelText->Len(), InOutModelText->Len() + RunParseResult.ContentRange.EndIndex - RunParseResult.ContentRange.BeginIndex);
+        InOutModelText->Append(OriginalText.Mid(RunParseResult.ContentRange.BeginIndex, RunParseResult.ContentRange.EndIndex - RunParseResult.ContentRange.BeginIndex));
+
+        // Create a text block style with our font and color
+        FTextBlockStyle TextStyle;
+        TextStyle.SetFont(Font);
+        TextStyle.SetColorAndOpacity(Color);
+
+        // Cast to const TSharedRef for the API
+        TSharedRef<const FString> ConstModelText = ConstCastSharedRef<const FString>(InOutModelText);
+
+        return FSlateTextRun::Create(RunInfo, ConstModelText, TextStyle, ModelRange);
+    }
+
+private:
+    FStyleTextDecorator(const FString& InRunName, const FSlateColor& InColor, const FSlateFontInfo& InFont)
+        : RunName(InRunName)
+        , Color(InColor)
+        , Font(InFont)
+    {}
+
+    FString RunName;
+    FSlateColor Color;
+    FSlateFontInfo Font;
+};
+
+// Static color definitions
+const FLinearColor SMarkdownWidget::HeadingColor = FLinearColor(0.85f, 0.85f, 0.9f);
+const FLinearColor SMarkdownWidget::LinkColor = FLinearColor(0.4f, 0.7f, 1.0f);
+const FLinearColor SMarkdownWidget::CodeBackgroundColor = FLinearColor(0.04f, 0.04f, 0.06f);
+const FLinearColor SMarkdownWidget::QuoteBackgroundColor = FLinearColor(0.08f, 0.08f, 0.10f);
+const FLinearColor SMarkdownWidget::QuoteAccentColor = FLinearColor(0.3f, 0.3f, 0.4f);
+
+// Static heading text styles (SRichTextBlock requires style pointers, not values)
+const FTextBlockStyle SMarkdownWidget::Heading1Style = FTextBlockStyle()
+    .SetFont(FCoreStyle::GetDefaultFontStyle("Bold", Heading1Size))
+    .SetColorAndOpacity(FSlateColor(HeadingColor));
+
+const FTextBlockStyle SMarkdownWidget::Heading2Style = FTextBlockStyle()
+    .SetFont(FCoreStyle::GetDefaultFontStyle("Bold", Heading2Size))
+    .SetColorAndOpacity(FSlateColor(HeadingColor));
+
+const FTextBlockStyle SMarkdownWidget::Heading3Style = FTextBlockStyle()
+    .SetFont(FCoreStyle::GetDefaultFontStyle("Bold", Heading3Size))
+    .SetColorAndOpacity(FSlateColor(HeadingColor));
+
+const FTextBlockStyle SMarkdownWidget::Heading4Style = FTextBlockStyle()
+    .SetFont(FCoreStyle::GetDefaultFontStyle("Bold", Heading4Size))
+    .SetColorAndOpacity(FSlateColor(HeadingColor));
+
+void SMarkdownWidget::Construct(const FArguments& InArgs)
+{
+    MarkdownText = InArgs._Text;
+    bDarkTheme = InArgs._bDarkTheme;
+    bSelectionModeAttr = InArgs._bSelectionMode;
+
+    // Create container for formatted content
+    SAssignNew(ContentBox, SVerticalBox);
+
+    // Create selectable text widget for selection mode
+    SAssignNew(SelectableTextBox, SMultiLineEditableText)
+    .Text(FText::FromString(GetPlainText()))
+    .TextStyle(FAppStyle::Get(), "NormalText")
+    .AutoWrapText(true)
+    .IsReadOnly(true);
+
+    // Build the widget without toggle buttons (mode controlled externally)
+    ChildSlot
+    [
+        SNew(SWidgetSwitcher)
+        .WidgetIndex_Lambda([this]() { return bSelectionModeAttr.Get() ? 1 : 0; })
+
+        // Index 0: Formatted markdown view
+        + SWidgetSwitcher::Slot()
+        [
+            ContentBox.ToSharedRef()
+        ]
+
+        // Index 1: Selectable plain text view
+        + SWidgetSwitcher::Slot()
+        [
+            SelectableTextBox.ToSharedRef()
+        ]
+    ];
+
+    // Initial render
+    RebuildWidget();
+}
+
+void SMarkdownWidget::SetText(const FString& NewText)
+{
+    if (MarkdownText != NewText)
+    {
+        MarkdownText = NewText;
+        RebuildWidget();
+    }
+}
+
+void SMarkdownWidget::RebuildWidget()
+{
+    // Update formatted content
+    if (ContentBox.IsValid())
+    {
+        ContentBox->ClearChildren();
+
+        if (!MarkdownText.IsEmpty())
+        {
+            // Parse markdown
+            TArray<FMarkdownElement> Elements = ParseMarkdown(MarkdownText);
+
+            // Build widgets
+            TSharedRef<SWidget> Content = BuildWidgetsFromElements(Elements);
+
+            // Add to container
+            ContentBox->AddSlot()
+            [
+                Content
+            ];
+        }
+    }
+
+    // Update selectable text box
+    if (SelectableTextBox.IsValid())
+    {
+        SelectableTextBox->SetText(FText::FromString(GetPlainText()));
+    }
+}
+
+// ============================================================================
+// Markdown Parsing
+// ============================================================================
+
+TArray<FMarkdownElement> SMarkdownWidget::ParseMarkdown(const FString& MarkdownText)
+{
+    TArray<FMarkdownElement> Elements;
+
+    // Split into lines
+    TArray<FString> Lines;
+    MarkdownText.ParseIntoArrayLines(Lines);
+
+    bool bInCodeBlock = false;
+    FString CodeBlockContent;
+    FString CodeBlockLang;
+    bool bInBlockQuote = false;
+    FString BlockQuoteContent;
+    int32 ListCounter = 0;
+    int32 BulletIndent = -1;  // Track bullet list indentation level
+
+    for (int32 i = 0; i < Lines.Num(); ++i)
+    {
+        FString Line = Lines[i];
+
+        // Handle code blocks
+        if (bInCodeBlock)
+        {
+            if (Line.TrimStartAndEnd().StartsWith(TEXT("```")))
+            {
+                // End code block
+                bInCodeBlock = false;
+                FMarkdownElement CodeElement(EMarkdownElementType::CodeBlock, CodeBlockContent);
+                CodeElement.Content = CodeBlockLang + TEXT("\n") + CodeBlockContent;
+                Elements.Add(CodeElement);
+                CodeBlockContent.Empty();
+                CodeBlockLang.Empty();
+            }
+            else
+            {
+                CodeBlockContent += Line + TEXT("\n");
+            }
+            continue;
+        }
+
+        // Check for code block start
+        FString TrimmedLine = Line.TrimStartAndEnd();
+        if (TrimmedLine.StartsWith(TEXT("```")))
+        {
+            bInCodeBlock = true;
+            CodeBlockLang = TrimmedLine.RightChop(3).TrimStartAndEnd();
+            CodeBlockContent.Empty();
+            continue;
+        }
+
+        // Handle block quotes
+        FString QuoteContent;
+        if (FMarkdownParser::IsBlockQuote(Line, QuoteContent))
+        {
+            bInBlockQuote = true;
+            BlockQuoteContent += QuoteContent + TEXT("\n");
+            continue;
+        }
+        else if (bInBlockQuote)
+        {
+            // End block quote
+            bInBlockQuote = false;
+            FMarkdownElement QuoteElement(EMarkdownElementType::BlockQuote, BlockQuoteContent.TrimEnd());
+            Elements.Add(QuoteElement);
+            BlockQuoteContent.Empty();
+        }
+
+        // Check for horizontal rule
+        if (FMarkdownParser::IsHorizontalRule(TrimmedLine))
+        {
+            Elements.Add(FMarkdownElement(EMarkdownElementType::HorizontalRule, TEXT("")));
+            continue;
+        }
+
+        // Check for heading
+        int32 HeadingLevel = 0;
+        FString HeadingContent;
+        if (FMarkdownParser::IsHeading(Line, HeadingLevel, HeadingContent))
+        {
+            EMarkdownElementType HeadingType = EMarkdownElementType::Heading1;
+            switch (HeadingLevel)
+            {
+                case 2: HeadingType = EMarkdownElementType::Heading2; break;
+                case 3: HeadingType = EMarkdownElementType::Heading3; break;
+                case 4: HeadingType = EMarkdownElementType::Heading4; break;
+                default: HeadingType = EMarkdownElementType::Heading1; break;
+            }
+            FMarkdownElement HeadingElement(HeadingType, HeadingContent);
+            HeadingElement.Children = ParseInlineFormatting(HeadingContent);
+            Elements.Add(HeadingElement);
+            continue;
+        }
+
+        // Check for bullet list
+        FString BulletContent;
+        int32 BulletIndentLevel = 0;
+        if (FMarkdownParser::IsBulletList(Line, BulletContent, BulletIndentLevel))
+        {
+            FMarkdownElement ListElement(EMarkdownElementType::BulletList, BulletContent);
+            ListElement.Level = BulletIndentLevel;
+            ListElement.Children = ParseInlineFormatting(BulletContent);
+            Elements.Add(ListElement);
+            continue;
+        }
+
+        // Check for numbered list
+        FString NumberedContent;
+        int32 Number = 0;
+    int32 NumberedIndent = 0;
+        if (FMarkdownParser::IsNumberedList(Line, NumberedContent, Number, NumberedIndent))
+        {
+            FMarkdownElement ListElement(EMarkdownElementType::NumberedList, NumberedContent);
+            ListElement.Level = Number;
+            ListElement.Children = ParseInlineFormatting(NumberedContent);
+            Elements.Add(ListElement);
+            continue;
+        }
+
+        // Check for table start
+        if (IsTableRow(Line))
+        {
+            // Check if next line is separator (valid table)
+            if (i + 1 < Lines.Num() && IsTableSeparator(Lines[i + 1]))
+            {
+                FMarkdownElement TableElement(EMarkdownElementType::Table, TEXT(""));
+                TableElement.TableRows.Add(ParseTableRowCells(Line));  // Header row
+                i++;  // Skip separator line
+
+                // Parse remaining table rows
+                while (i + 1 < Lines.Num() && IsTableRow(Lines[i + 1]))
+                {
+                    i++;
+                    TableElement.TableRows.Add(ParseTableRowCells(Lines[i]));
+                }
+                Elements.Add(TableElement);
+                continue;
+            }
+        }
+
+        // Empty line - start new paragraph
+        if (TrimmedLine.IsEmpty())
+        {
+            continue;
+        }
+
+        // Regular paragraph
+        FMarkdownElement ParaElement(EMarkdownElementType::Paragraph, Line);
+        ParaElement.Children = ParseInlineFormatting(Line);
+        Elements.Add(ParaElement);
+    }
+
+    // Close any open blocks
+    if (bInCodeBlock)
+    {
+        FMarkdownElement CodeElement(EMarkdownElementType::CodeBlock, CodeBlockContent);
+        Elements.Add(CodeElement);
+    }
+    if (bInBlockQuote)
+    {
+        FMarkdownElement QuoteElement(EMarkdownElementType::BlockQuote, BlockQuoteContent.TrimEnd());
+        Elements.Add(QuoteElement);
+    }
+
+    return Elements;
+}
+
+TArray<FMarkdownElement> SMarkdownWidget::ParseInlineFormatting(const FString& Text)
+{
+    TArray<FMarkdownElement> Elements;
+
+    int32 Pos = 0;
+    FString CurrentText;
+
+    while (Pos < Text.Len())
+    {
+        // Check for inline code `...`
+        if (Text[Pos] == '`')
+        {
+            // Add any accumulated text first
+            if (!CurrentText.IsEmpty())
+            {
+                Elements.Add(FMarkdownElement(EMarkdownElementType::Paragraph, CurrentText));
+                CurrentText.Empty();
+            }
+
+            // Find closing `
+            int32 EndPos = Text.Find(TEXT("`"), ESearchCase::CaseSensitive, ESearchDir::FromStart, Pos + 1);
+            if (EndPos != INDEX_NONE)
+            {
+                FString CodeText = Text.Mid(Pos + 1, EndPos - Pos - 1);
+                Elements.Add(FMarkdownElement(EMarkdownElementType::InlineCode, CodeText));
+                Pos = EndPos + 1;
+            }
+            else
+            {
+                // No closing, treat as regular char
+                CurrentText += '`';
+                Pos++;
+            }
+            continue;
+        }
+
+        // Check for bold **...** or __...__
+        bool bIsBold = false;
+        FString BoldMarker;
+        if (Pos + 1 < Text.Len())
+        {
+            if (Text[Pos] == '*' && Text[Pos + 1] == '*')
+            {
+                bIsBold = true;
+                BoldMarker = TEXT("**");
+            }
+            else if (Text[Pos] == '_' && Text[Pos + 1] == '_')
+            {
+                bIsBold = true;
+                BoldMarker = TEXT("__");
+            }
+        }
+
+        if (bIsBold)
+        {
+            // Add accumulated text
+            if (!CurrentText.IsEmpty())
+            {
+                Elements.Add(FMarkdownElement(EMarkdownElementType::Paragraph, CurrentText));
+                CurrentText.Empty();
+            }
+
+            // Find closing marker
+            int32 EndPos = Text.Find(BoldMarker, ESearchCase::CaseSensitive, ESearchDir::FromStart, Pos + 2);
+            if (EndPos != INDEX_NONE)
+            {
+                FString BoldText = Text.Mid(Pos + 2, EndPos - Pos - 2);
+                FMarkdownElement BoldElement(EMarkdownElementType::Bold, BoldText);
+                // Check for nested italic ***bold italic***
+                if (BoldText.StartsWith(TEXT("*")) && BoldText.EndsWith(TEXT("*")))
+                {
+                    BoldElement.Type = EMarkdownElementType::BoldItalic;
+                    BoldElement.Content = BoldText.Mid(1, BoldText.Len() - 2);
+                }
+                Elements.Add(BoldElement);
+                Pos = EndPos + 2;
+            }
+            else
+            {
+                CurrentText += BoldMarker;
+                Pos += 2;
+            }
+            continue;
+        }
+
+        // Check for italic *...* or _..._
+        // For _: only treat as italic if preceded by whitespace/punctuation and followed by non-underscore
+        // This prevents "GE_GCS_Hit_V2" from being parsed as italic
+        bool bIsItalic = false;
+        FString ItalicMarker;
+
+        if (Pos < Text.Len())
+        {
+            // * italic: always valid if not followed by another *
+            if (Text[Pos] == '*' && (Pos + 1 >= Text.Len() || Text[Pos + 1] != '*'))
+            {
+                bIsItalic = true;
+                ItalicMarker = TEXT("*");
+            }
+            // _ italic: only if not preceded/followed by alphanumeric (intra-word underscore protection)
+            else if (Text[Pos] == '_' && (Pos + 1 >= Text.Len() || Text[Pos + 1] != '_'))
+            {
+                // Check if preceded by alphanumeric (word character)
+                bool bPrecededByWordChar = (Pos > 0 && IsAlphanumeric(Text[Pos - 1]));
+                // Check if followed by alphanumeric (word character)
+                bool bFollowedByWordChar = (Pos + 1 < Text.Len() && IsAlphanumeric(Text[Pos + 1]));
+
+                // Only treat as italic if NOT inside a word
+                if (!bPrecededByWordChar && !bFollowedByWordChar)
+                {
+                    bIsItalic = true;
+                    ItalicMarker = TEXT("_");
+                }
+            }
+        }
+
+        if (bIsItalic)
+        {
+            // Add accumulated text
+            if (!CurrentText.IsEmpty())
+            {
+                Elements.Add(FMarkdownElement(EMarkdownElementType::Paragraph, CurrentText));
+                CurrentText.Empty();
+            }
+
+            // Find closing marker
+            int32 EndPos = INDEX_NONE;
+
+            if (ItalicMarker == TEXT("*"))
+            {
+                // * marker: find next * that's not part of **
+                for (int32 SearchPos = Pos + 1; SearchPos < Text.Len(); ++SearchPos)
+                {
+                    if (Text[SearchPos] == '*')
+                    {
+                        // Make sure it's not part of ** (bold)
+                        if (SearchPos + 1 >= Text.Len() || Text[SearchPos + 1] != '*')
+                        {
+                            EndPos = SearchPos;
+                            break;
+                        }
+                    }
+                }
+            }
+            else if (ItalicMarker == TEXT("_"))
+            {
+                // _ marker: find next _ that's not preceded/followed by alphanumeric
+                for (int32 SearchPos = Pos + 1; SearchPos < Text.Len(); ++SearchPos)
+                {
+                    if (Text[SearchPos] == '_' && (SearchPos + 1 >= Text.Len() || Text[SearchPos + 1] != '_'))
+                    {
+                        // Check if this _ is at word boundary
+                        bool bEndPrecededByWordChar = (SearchPos > 0 && IsAlphanumeric(Text[SearchPos - 1]));
+                        bool bEndFollowedByWordChar = (SearchPos + 1 < Text.Len() && IsAlphanumeric(Text[SearchPos + 1]));
+
+                        if (!bEndPrecededByWordChar && !bEndFollowedByWordChar)
+                        {
+                            EndPos = SearchPos;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (EndPos != INDEX_NONE)
+            {
+                FString ItalicText = Text.Mid(Pos + 1, EndPos - Pos - 1);
+                // Make sure italic text is not empty and not just underscores
+                if (!ItalicText.IsEmpty() && ItalicText.TrimStartAndEnd() != TEXT("_"))
+                {
+                    Elements.Add(FMarkdownElement(EMarkdownElementType::Italic, ItalicText));
+                    Pos = EndPos + 1;
+                }
+                else
+                {
+                    // Invalid italic - keep the marker as regular text
+                    CurrentText += ItalicMarker;
+                    Pos++;
+                }
+            }
+            else
+            {
+                CurrentText += ItalicMarker;
+                Pos++;
+            }
+            continue;
+        }
+
+        // Check for link [text](url)
+        if (Text[Pos] == '[')
+        {
+            // Add accumulated text
+            if (!CurrentText.IsEmpty())
+            {
+                Elements.Add(FMarkdownElement(EMarkdownElementType::Paragraph, CurrentText));
+                CurrentText.Empty();
+            }
+
+            // Find closing ]
+            int32 BracketEnd = Text.Find(TEXT("]"), ESearchCase::CaseSensitive, ESearchDir::FromStart, Pos + 1);
+            if (BracketEnd != INDEX_NONE && BracketEnd + 1 < Text.Len() && Text[BracketEnd + 1] == '(')
+            {
+                // Find closing )
+                int32 ParenEnd = Text.Find(TEXT(")"), ESearchCase::CaseSensitive, ESearchDir::FromStart, BracketEnd + 2);
+                if (ParenEnd != INDEX_NONE)
+                {
+                    FString LinkText = Text.Mid(Pos + 1, BracketEnd - Pos - 1);
+                    FString LinkUrl = Text.Mid(BracketEnd + 2, ParenEnd - BracketEnd - 2);
+                    FMarkdownElement LinkElement(EMarkdownElementType::Link, LinkText);
+                    LinkElement.Url = LinkUrl;
+                    Elements.Add(LinkElement);
+                    Pos = ParenEnd + 1;
+                    continue;
+                }
+            }
+            // Invalid link syntax, treat as regular
+            CurrentText += '[';
+            Pos++;
+            continue;
+        }
+
+        // Regular character
+        CurrentText += Text[Pos];
+        Pos++;
+    }
+
+    // Add remaining text
+    if (!CurrentText.IsEmpty())
+    {
+        Elements.Add(FMarkdownElement(EMarkdownElementType::Paragraph, CurrentText));
+    }
+
+    return Elements;
+}
+
+// ============================================================================
+// Widget Building
+// ============================================================================
+
+TSharedRef<SWidget> SMarkdownWidget::BuildWidgetsFromElements(const TArray<FMarkdownElement>& Elements)
+{
+    TSharedPtr<SVerticalBox> VBox;
+    SAssignNew(VBox, SVerticalBox);
+
+    for (const FMarkdownElement& Element : Elements)
+    {
+        TSharedPtr<SWidget> Widget;
+
+        switch (Element.Type)
+        {
+            case EMarkdownElementType::Heading1:
+            case EMarkdownElementType::Heading2:
+            case EMarkdownElementType::Heading3:
+            case EMarkdownElementType::Heading4:
+                Widget = BuildHeading(Element);
+                break;
+
+            case EMarkdownElementType::Paragraph:
+                Widget = BuildParagraph(Element);
+                break;
+
+            case EMarkdownElementType::CodeBlock:
+                Widget = BuildCodeBlock(Element);
+                break;
+
+            case EMarkdownElementType::BulletList:
+                Widget = BuildListItem(Element, Element.Level);
+                break;
+
+            case EMarkdownElementType::NumberedList:
+                Widget = BuildListItem(Element, 0);
+                break;
+
+            case EMarkdownElementType::Link:
+                Widget = BuildLink(Element);
+                break;
+
+            case EMarkdownElementType::BlockQuote:
+                Widget = BuildBlockQuote(Element);
+                break;
+
+            case EMarkdownElementType::Table:
+                Widget = BuildTable(Element);
+                break;
+
+            case EMarkdownElementType::HorizontalRule:
+                Widget = BuildHorizontalRule();
+                break;
+
+            default:
+                Widget = BuildParagraph(Element);
+                break;
+        }
+
+        if (Widget.IsValid())
+        {
+            VBox->AddSlot()
+            .AutoHeight()
+            .Padding(FMargin(0.0f, 2.0f))
+            [
+                Widget.ToSharedRef()
+            ];
+        }
+    }
+
+    return VBox.ToSharedRef();
+}
+
+TSharedRef<SWidget> SMarkdownWidget::BuildParagraph(const FMarkdownElement& Element)
+{
+    // Convert inline elements to rich text markup format
+    FString RichTextMarkup;
+
+    if (Element.Children.Num() > 0)
+    {
+        for (const FMarkdownElement& Child : Element.Children)
+        {
+            switch (Child.Type)
+            {
+                case EMarkdownElementType::Bold:
+                    RichTextMarkup += FString::Printf(TEXT("<Bold>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::Italic:
+                    RichTextMarkup += FString::Printf(TEXT("<Italic>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::BoldItalic:
+                    RichTextMarkup += FString::Printf(TEXT("<BoldItalic>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::InlineCode:
+                    RichTextMarkup += FString::Printf(TEXT("<CodeInline>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::Link:
+                    // Links need special handling - store URL and use hyperlink decorator
+                    RichTextMarkup += FString::Printf(TEXT("<a href=\"%s\">%s</>"), *Child.Url, *Child.Content);
+                    break;
+                default:
+                    // Escape any special characters in plain text
+                    FString EscapedContent = Child.Content;
+                    // Replace & with &amp; first to avoid double escaping
+                    EscapedContent.ReplaceInline(TEXT("&"), TEXT("&amp;"), ESearchCase::CaseSensitive);
+                    // Replace < with &lt; and > with &gt; to avoid markup confusion
+                    EscapedContent.ReplaceInline(TEXT("<"), TEXT("&lt;"), ESearchCase::CaseSensitive);
+                    EscapedContent.ReplaceInline(TEXT(">"), TEXT("&gt;"), ESearchCase::CaseSensitive);
+                    RichTextMarkup += EscapedContent;
+                    break;
+            }
+        }
+    }
+    else
+    {
+        // Plain text - escape special characters
+        FString EscapedContent = Element.Content;
+        EscapedContent.ReplaceInline(TEXT("&"), TEXT("&amp;"), ESearchCase::CaseSensitive);
+        EscapedContent.ReplaceInline(TEXT("<"), TEXT("&lt;"), ESearchCase::CaseSensitive);
+        EscapedContent.ReplaceInline(TEXT(">"), TEXT("&gt;"), ESearchCase::CaseSensitive);
+        RichTextMarkup = EscapedContent;
+    }
+
+    // Create custom text decorators for our markup
+    TArray<TSharedRef<ITextDecorator>> Decorators;
+
+    // Bold decorator
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("Bold"),
+        FSlateColor(FLinearColor::White),
+        FCoreStyle::GetDefaultFontStyle("Bold", NormalTextSize)
+    ));
+
+    // Italic decorator
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("Italic"),
+        FSlateColor(FLinearColor::White),
+        FCoreStyle::GetDefaultFontStyle("Italic", NormalTextSize)
+    ));
+
+    // BoldItalic decorator
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("BoldItalic"),
+        FSlateColor(FLinearColor::White),
+        FCoreStyle::GetDefaultFontStyle("BoldItalic", NormalTextSize)
+    ));
+
+    // Inline code decorator
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("CodeInline"),
+        FSlateColor(FLinearColor(0.8f, 0.85f, 0.75f)),
+        FCoreStyle::GetDefaultFontStyle("Mono", CodeTextSize)
+    ));
+
+    // Use SRichTextBlock for proper text wrapping across inline elements
+    return SNew(SRichTextBlock)
+        .Text(FText::FromString(RichTextMarkup))
+        .AutoWrapText(true)
+        .Decorators(Decorators)
+        .TextStyle(FAppStyle::Get(), "NormalText");
+}
+
+TSharedRef<SWidget> SMarkdownWidget::BuildHeading(const FMarkdownElement& Element)
+{
+    float FontSize = NormalTextSize;
+    const FTextBlockStyle* HeadingStylePtr = &FCoreStyle::Get().GetWidgetStyle<FTextBlockStyle>("NormalText");
+
+    switch (Element.Type)
+    {
+        case EMarkdownElementType::Heading1:
+            FontSize = Heading1Size;
+            HeadingStylePtr = &Heading1Style;
+            break;
+        case EMarkdownElementType::Heading2:
+            FontSize = Heading2Size;
+            HeadingStylePtr = &Heading2Style;
+            break;
+        case EMarkdownElementType::Heading3:
+            FontSize = Heading3Size;
+            HeadingStylePtr = &Heading3Style;
+            break;
+        case EMarkdownElementType::Heading4:
+            FontSize = Heading4Size;
+            HeadingStylePtr = &Heading4Style;
+            break;
+        default:
+            break;
+    }
+
+    // Convert inline elements to rich text markup format
+    FString RichTextMarkup;
+
+    if (Element.Children.Num() > 0)
+    {
+        for (const FMarkdownElement& Child : Element.Children)
+        {
+            switch (Child.Type)
+            {
+                case EMarkdownElementType::Bold:
+                    RichTextMarkup += FString::Printf(TEXT("<Bold>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::Italic:
+                    RichTextMarkup += FString::Printf(TEXT("<Italic>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::BoldItalic:
+                    RichTextMarkup += FString::Printf(TEXT("<BoldItalic>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::InlineCode:
+                    RichTextMarkup += FString::Printf(TEXT("<CodeInline>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::Link:
+                    RichTextMarkup += FString::Printf(TEXT("<a href=\"%s\">%s</>"), *Child.Url, *Child.Content);
+                    break;
+                default:
+                    FString EscapedContent = Child.Content;
+                    EscapedContent.ReplaceInline(TEXT("&"), TEXT("&amp;"), ESearchCase::CaseSensitive);
+                    EscapedContent.ReplaceInline(TEXT("<"), TEXT("&lt;"), ESearchCase::CaseSensitive);
+                    EscapedContent.ReplaceInline(TEXT(">"), TEXT("&gt;"), ESearchCase::CaseSensitive);
+                    RichTextMarkup += EscapedContent;
+                    break;
+            }
+        }
+    }
+    else
+    {
+        FString EscapedContent = Element.Content;
+        EscapedContent.ReplaceInline(TEXT("&"), TEXT("&amp;"), ESearchCase::CaseSensitive);
+        EscapedContent.ReplaceInline(TEXT("<"), TEXT("&lt;"), ESearchCase::CaseSensitive);
+        EscapedContent.ReplaceInline(TEXT(">"), TEXT("&gt;"), ESearchCase::CaseSensitive);
+        RichTextMarkup = EscapedContent;
+    }
+
+    // Create custom text decorators for our markup with heading font size
+    TArray<TSharedRef<ITextDecorator>> Decorators;
+
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("Bold"),
+        FSlateColor(HeadingColor),
+        FCoreStyle::GetDefaultFontStyle("Bold", FontSize)
+    ));
+
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("Italic"),
+        FSlateColor(HeadingColor),
+        FCoreStyle::GetDefaultFontStyle("Italic", FontSize)
+    ));
+
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("BoldItalic"),
+        FSlateColor(HeadingColor),
+        FCoreStyle::GetDefaultFontStyle("BoldItalic", FontSize)
+    ));
+
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("CodeInline"),
+        FSlateColor(FLinearColor(0.8f, 0.85f, 0.75f)),
+        FCoreStyle::GetDefaultFontStyle("Mono", FontSize - 1.0f)
+    ));
+
+    return SNew(SBox)
+    .Padding(FMargin(0.0f, 8.0f, 0.0f, 4.0f))
+    [
+        SNew(SRichTextBlock)
+        .Text(FText::FromString(RichTextMarkup))
+        .AutoWrapText(true)
+        .Decorators(Decorators)
+        .TextStyle(HeadingStylePtr)
+    ];
+}
+
+TSharedRef<SWidget> SMarkdownWidget::BuildCodeBlock(const FMarkdownElement& Element)
+{
+    // Extract language tag and content
+    FString Content = Element.Content;
+    FString LangTag;
+    int32 NewlinePos = Content.Find(TEXT("\n"));
+    if (NewlinePos != INDEX_NONE)
+    {
+        LangTag = Content.Left(NewlinePos);
+        Content = Content.RightChop(NewlinePos + 1);
+    }
+    Content.TrimEndInline();
+
+    // Store content for copy button
+    FString CodeContent = Content;
+
+    // Code block styling - more distinct like table
+    const FLinearColor CodeBlockBorderColor = FLinearColor(0.35f, 0.35f, 0.40f);  // Visible border
+    const FLinearColor CodeBlockBgColor = FLinearColor(0.10f, 0.10f, 0.12f);      // Distinct background
+    const FLinearColor CodeBlockAccentColor = FLinearColor(0.15f, 0.22f, 0.30f);     // Accent bar color (dimmed blue)
+
+    return SNew(SHorizontalBox)
+
+    // Accent bar on left (similar to block quote)
+    + SHorizontalBox::Slot()
+    .AutoWidth()
+    [
+        SNew(SBorder)
+        .BorderImage(FAppStyle::GetBrush("WhiteBrush"))
+        .BorderBackgroundColor(CodeBlockAccentColor)
+        .Padding(FMargin(4.0f, 0.0f))
+        [
+            SNullWidget::NullWidget
+        ]
+    ]
+
+    // Code content with border
+    + SHorizontalBox::Slot()
+    .FillWidth(1.0f)
+    [
+        SNew(SBorder)
+        .BorderImage(FAppStyle::GetBrush("ToolPanel.DarkGroupBorder"))
+        .BorderBackgroundColor(CodeBlockBorderColor)
+        .Padding(FMargin(1.0f))
+        [
+            SNew(SBorder)
+            .BorderBackgroundColor(CodeBlockBgColor)
+            .Padding(FMargin(10.0f, 8.0f))
+            [
+                SNew(SVerticalBox)
+
+                // Header row with language tag
+                + SVerticalBox::Slot()
+                .AutoHeight()
+                .Padding(0, 0, 0, 4)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(LangTag.IsEmpty() ? TEXT("code") : LangTag))
+                    .Font(FCoreStyle::GetDefaultFontStyle("Mono", 8))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.5f, 0.6f, 0.7f)))
+                    .Visibility_Lambda([LangTag]() { return LangTag.IsEmpty() ? EVisibility::Collapsed : EVisibility::Visible; })
+                ]
+
+                // Code content
+                + SVerticalBox::Slot()
+                .AutoHeight()
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(Content))
+                    .Font(FCoreStyle::GetDefaultFontStyle("Mono", CodeTextSize))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.85f, 0.90f, 0.80f)))
+                    .AutoWrapText(true)
+                ]
+            ]
+        ]
+    ]
+
+    // Copy button on right side (vertical aligned)
+    + SHorizontalBox::Slot()
+    .AutoWidth()
+    .VAlign(VAlign_Top)
+    .Padding(4.0f, 8.0f, 4.0f, 0.0f)
+    [
+        SNew(SButton)
+        .Text(LOCTEXT("CopyCode", "Copy"))
+        .ButtonStyle(FAppStyle::Get(), "SimpleButton")
+        .OnClicked_Lambda([CodeContent]()
+        {
+            FPlatformApplicationMisc::ClipboardCopy(*CodeContent);
+            return FReply::Handled();
+        })
+        .ToolTipText(LOCTEXT("CopyCodeTooltip", "Copy code to clipboard"))
+    ];
+}
+
+TSharedRef<SWidget> SMarkdownWidget::BuildListItem(const FMarkdownElement& Element, int32 IndentLevel)
+{
+    float Indent = IndentLevel * 20.0f + 12.0f;
+    FString Prefix;
+
+    if (Element.Type == EMarkdownElementType::BulletList)
+    {
+        Prefix = TEXT("• ");
+    }
+    else
+    {
+        Prefix = FString::Printf(TEXT("%d. "), Element.Level);
+    }
+
+    // Convert inline elements to rich text markup format
+    FString RichTextMarkup;
+
+    if (Element.Children.Num() > 0)
+    {
+        for (const FMarkdownElement& Child : Element.Children)
+        {
+            switch (Child.Type)
+            {
+                case EMarkdownElementType::Bold:
+                    RichTextMarkup += FString::Printf(TEXT("<Bold>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::Italic:
+                    RichTextMarkup += FString::Printf(TEXT("<Italic>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::BoldItalic:
+                    RichTextMarkup += FString::Printf(TEXT("<BoldItalic>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::InlineCode:
+                    RichTextMarkup += FString::Printf(TEXT("<CodeInline>%s</>"), *Child.Content);
+                    break;
+                case EMarkdownElementType::Link:
+                    RichTextMarkup += FString::Printf(TEXT("<a href=\"%s\">%s</>"), *Child.Url, *Child.Content);
+                    break;
+                default:
+                    FString EscapedContent = Child.Content;
+                    EscapedContent.ReplaceInline(TEXT("&"), TEXT("&amp;"), ESearchCase::CaseSensitive);
+                    EscapedContent.ReplaceInline(TEXT("<"), TEXT("&lt;"), ESearchCase::CaseSensitive);
+                    EscapedContent.ReplaceInline(TEXT(">"), TEXT("&gt;"), ESearchCase::CaseSensitive);
+                    RichTextMarkup += EscapedContent;
+                    break;
+            }
+        }
+    }
+    else
+    {
+        FString EscapedContent = Element.Content;
+        EscapedContent.ReplaceInline(TEXT("&"), TEXT("&amp;"), ESearchCase::CaseSensitive);
+        EscapedContent.ReplaceInline(TEXT("<"), TEXT("&lt;"), ESearchCase::CaseSensitive);
+        EscapedContent.ReplaceInline(TEXT(">"), TEXT("&gt;"), ESearchCase::CaseSensitive);
+        RichTextMarkup = EscapedContent;
+    }
+
+    // Create custom text decorators for our markup
+    TArray<TSharedRef<ITextDecorator>> Decorators;
+
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("Bold"),
+        FSlateColor(FLinearColor::White),
+        FCoreStyle::GetDefaultFontStyle("Bold", NormalTextSize)
+    ));
+
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("Italic"),
+        FSlateColor(FLinearColor::White),
+        FCoreStyle::GetDefaultFontStyle("Italic", NormalTextSize)
+    ));
+
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("BoldItalic"),
+        FSlateColor(FLinearColor::White),
+        FCoreStyle::GetDefaultFontStyle("BoldItalic", NormalTextSize)
+    ));
+
+    Decorators.Add(FStyleTextDecorator::Create(
+        TEXT("CodeInline"),
+        FSlateColor(FLinearColor(0.8f, 0.85f, 0.75f)),
+        FCoreStyle::GetDefaultFontStyle("Mono", CodeTextSize)
+    ));
+
+    // Combine prefix + content in a horizontal box
+    return SNew(SHorizontalBox)
+    + SHorizontalBox::Slot()
+    .AutoWidth()
+    [
+        SNew(STextBlock)
+        .Text(FText::FromString(Prefix))
+        .TextStyle(FAppStyle::Get(), "NormalText")
+    ]
+    + SHorizontalBox::Slot()
+    .FillWidth(1.0f)
+    [
+        SNew(SBox)
+        .Padding(FMargin(Indent, 2.0f, 0.0f, 2.0f))
+        [
+            SNew(SRichTextBlock)
+            .Text(FText::FromString(RichTextMarkup))
+            .AutoWrapText(true)
+            .Decorators(Decorators)
+            .TextStyle(FAppStyle::Get(), "NormalText")
+        ]
+    ];
+}
+
+TSharedRef<SWidget> SMarkdownWidget::BuildLink(const FMarkdownElement& Element)
+{
+    FString Url = Element.Url;
+    if (!Url.StartsWith(TEXT("http://")) && !Url.StartsWith(TEXT("https://")))
+    {
+        Url = TEXT("https://") + Url;
+    }
+
+    return SNew(SHyperlink)
+    .Text(FText::FromString(Element.Content))
+    .Style(FCoreStyle::Get(), "Hyperlink")
+    .OnNavigate_Lambda([Url]()
+    {
+        FString PlatformUrl = Url;
+        FPlatformProcess::LaunchURL(*PlatformUrl, nullptr, nullptr);
+    });
+}
+
+TSharedRef<SWidget> SMarkdownWidget::BuildBlockQuote(const FMarkdownElement& Element)
+{
+    return SNew(SHorizontalBox)
+
+    // Accent bar
+    + SHorizontalBox::Slot()
+    .AutoWidth()
+    [
+        SNew(SBorder)
+        .BorderImage(FAppStyle::GetBrush("WhiteBrush"))
+        .BorderBackgroundColor(QuoteAccentColor)
+        .Padding(FMargin(3.0f, 0.0f))
+        [
+            SNullWidget::NullWidget
+        ]
+    ]
+
+    // Quote content
+    + SHorizontalBox::Slot()
+    .FillWidth(1.0f)
+    [
+        SNew(SBorder)
+        .BorderImage(FAppStyle::GetBrush("ToolPanel.DarkGroupBorder"))
+        .BorderBackgroundColor(QuoteBackgroundColor)
+        .Padding(FMargin(12.0f, 8.0f))
+        [
+            SNew(STextBlock)
+            .Text(FText::FromString(Element.Content))
+            .TextStyle(FAppStyle::Get(), "NormalText")
+            .ColorAndOpacity(FSlateColor(FLinearColor(0.7f, 0.7f, 0.75f)))
+            .AutoWrapText(true)
+        ]
+    ];
+}
+
+TSharedRef<SWidget> SMarkdownWidget::BuildTable(const FMarkdownElement& Element)
+{
+    if (Element.TableRows.Num() == 0)
+    {
+        return SNullWidget::NullWidget;
+    }
+
+    int32 NumCols = Element.TableRows[0].Num();
+    if (NumCols == 0)
+    {
+        return SNullWidget::NullWidget;
+    }
+
+    // Separator line color (visible grid lines)
+    const FLinearColor SeparatorColor = FLinearColor(0.25f, 0.25f, 0.30f);
+    const FLinearColor HeaderBgColor = FLinearColor(0.12f, 0.12f, 0.15f);
+    const FLinearColor RowBgColor1 = FLinearColor(0.06f, 0.06f, 0.08f);
+    const FLinearColor RowBgColor2 = FLinearColor(0.04f, 0.04f, 0.06f);
+
+    // Use SGridPanel for proper column width alignment
+    TSharedPtr<SGridPanel> GridPanel;
+    SAssignNew(GridPanel, SGridPanel);
+
+    // Create common decorators for all cells
+    TArray<TSharedRef<ITextDecorator>> Decorators;
+    Decorators.Add(FStyleTextDecorator::Create(TEXT("Bold"), FSlateColor(FLinearColor::White), FCoreStyle::GetDefaultFontStyle("Bold", NormalTextSize)));
+    Decorators.Add(FStyleTextDecorator::Create(TEXT("Italic"), FSlateColor(FLinearColor::White), FCoreStyle::GetDefaultFontStyle("Italic", NormalTextSize)));
+    Decorators.Add(FStyleTextDecorator::Create(TEXT("BoldItalic"), FSlateColor(FLinearColor::White), FCoreStyle::GetDefaultFontStyle("BoldItalic", NormalTextSize)));
+    Decorators.Add(FStyleTextDecorator::Create(TEXT("CodeInline"), FSlateColor(FLinearColor(0.8f, 0.85f, 0.75f)), FCoreStyle::GetDefaultFontStyle("Mono", CodeTextSize)));
+
+    // Build all cells
+    for (int32 RowIdx = 0; RowIdx < Element.TableRows.Num(); ++RowIdx)
+    {
+        const TArray<FString>& RowCells = Element.TableRows[RowIdx];
+        bool bIsHeader = (RowIdx == 0);
+        FLinearColor BgColor = bIsHeader ? HeaderBgColor : ((RowIdx % 2 == 1) ? RowBgColor1 : RowBgColor2);
+
+        for (int32 Col = 0; Col < NumCols; ++Col)
+        {
+            FString CellText = (Col < RowCells.Num()) ? RowCells[Col].TrimStartAndEnd() : TEXT("");
+            FString RichTextMarkup = BuildCellMarkup(CellText, bIsHeader, Decorators);
+
+            // Add cell to grid
+            GridPanel->AddSlot(Col, RowIdx)
+            [
+                SNew(SBorder)
+                .BorderBackgroundColor(BgColor)
+                .Padding(FMargin(8.0f, 6.0f, 8.0f, 6.0f))
+                [
+                    SNew(SRichTextBlock)
+                    .Text(FText::FromString(RichTextMarkup))
+                    .AutoWrapText(true)
+                    .Decorators(Decorators)
+                    .TextStyle(FAppStyle::Get(), "NormalText")
+                ]
+            ];
+        }
+    }
+
+    // Wrap in horizontal box to prevent filling entire page
+    return SNew(SHorizontalBox)
+    + SHorizontalBox::Slot()
+    .AutoWidth()
+    .HAlign(HAlign_Left)
+    [
+        SNew(SBorder)
+        .BorderImage(FAppStyle::GetBrush("ToolPanel.DarkGroupBorder"))
+        .BorderBackgroundColor(SeparatorColor)
+        .Padding(FMargin(1.0f))
+        [
+            SNew(SBorder)
+            .BorderBackgroundColor(FLinearColor(0.05f, 0.05f, 0.07f))
+            .Padding(FMargin(0.0f))
+            [
+                GridPanel.ToSharedRef()
+            ]
+        ]
+    ]
+    // Spacer to fill remaining width
+    + SHorizontalBox::Slot()
+    .FillWidth(1.0f)
+    [
+        SNullWidget::NullWidget
+    ];
+}
+
+FString SMarkdownWidget::BuildCellMarkup(const FString& CellText, bool bIsHeader, const TArray<TSharedRef<ITextDecorator>>& Decorators)
+{
+    TArray<FMarkdownElement> InlineElements = ParseInlineFormatting(CellText);
+    FString RichTextMarkup;
+
+    if (InlineElements.Num() > 0)
+    {
+        for (const FMarkdownElement& InlineElement : InlineElements)
+        {
+            switch (InlineElement.Type)
+            {
+                case EMarkdownElementType::Bold:
+                    RichTextMarkup += FString::Printf(TEXT("<Bold>%s</>"), *InlineElement.Content);
+                    break;
+                case EMarkdownElementType::Italic:
+                    RichTextMarkup += FString::Printf(TEXT("<Italic>%s</>"), *InlineElement.Content);
+                    break;
+                case EMarkdownElementType::BoldItalic:
+                    RichTextMarkup += FString::Printf(TEXT("<BoldItalic>%s</>"), *InlineElement.Content);
+                    break;
+                case EMarkdownElementType::InlineCode:
+                    RichTextMarkup += FString::Printf(TEXT("<CodeInline>%s</>"), *InlineElement.Content);
+                    break;
+                case EMarkdownElementType::Link:
+                    RichTextMarkup += FString::Printf(TEXT("<a href=\"%s\">%s</>"), *InlineElement.Url, *InlineElement.Content);
+                    break;
+                default:
+                    if (bIsHeader)
+                    {
+                        FString EscapedContent = InlineElement.Content;
+                        EscapedContent.ReplaceInline(TEXT("&"), TEXT("&amp;"), ESearchCase::CaseSensitive);
+                        EscapedContent.ReplaceInline(TEXT("<"), TEXT("&lt;"), ESearchCase::CaseSensitive);
+                        EscapedContent.ReplaceInline(TEXT(">"), TEXT("&gt;"), ESearchCase::CaseSensitive);
+                        RichTextMarkup += FString::Printf(TEXT("<Bold>%s</>"), *EscapedContent);
+                    }
+                    else
+                    {
+                        FString EscapedContent = InlineElement.Content;
+                        EscapedContent.ReplaceInline(TEXT("&"), TEXT("&amp;"), ESearchCase::CaseSensitive);
+                        EscapedContent.ReplaceInline(TEXT("<"), TEXT("&lt;"), ESearchCase::CaseSensitive);
+                        EscapedContent.ReplaceInline(TEXT(">"), TEXT("&gt;"), ESearchCase::CaseSensitive);
+                        RichTextMarkup += EscapedContent;
+                    }
+                    break;
+            }
+        }
+    }
+    else if (bIsHeader)
+    {
+        RichTextMarkup = TEXT("<Bold></>");
+    }
+
+    return RichTextMarkup;
+}
+
+bool SMarkdownWidget::IsTableRow(const FString& Line)
+{
+    FString Trimmed = Line.TrimStartAndEnd();
+    return Trimmed.Len() > 2 && Trimmed.StartsWith(TEXT("|")) && Trimmed.EndsWith(TEXT("|"));
+}
+
+bool SMarkdownWidget::IsTableSeparator(const FString& Line)
+{
+    FString Trimmed = Line.TrimStartAndEnd();
+    if (!Trimmed.StartsWith(TEXT("|")) || !Trimmed.EndsWith(TEXT("|")))
+    {
+        return false;
+    }
+
+    // Check content between pipes is only dashes and spaces
+    FString Content = Trimmed.Mid(1, Trimmed.Len() - 2);
+    for (int32 i = 0; i < Content.Len(); ++i)
+    {
+        if (Content[i] != '-' && Content[i] != ' ' && Content[i] != '|')
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+TArray<FString> SMarkdownWidget::ParseTableRowCells(const FString& Line)
+{
+    TArray<FString> Cells;
+
+    FString Trimmed = Line.TrimStartAndEnd();
+    // Remove leading and trailing pipes
+    if (Trimmed.StartsWith(TEXT("|")))
+    {
+        Trimmed = Trimmed.RightChop(1);
+    }
+    if (Trimmed.EndsWith(TEXT("|")))
+    {
+        Trimmed = Trimmed.LeftChop(1);
+    }
+
+    // Split by | and trim each cell
+    TArray<FString> RawCells;
+    Trimmed.ParseIntoArray(RawCells, TEXT("|"));
+
+    for (const FString& Cell : RawCells)
+    {
+        Cells.Add(Cell.TrimStartAndEnd());
+    }
+
+    return Cells;
+}
+
+TSharedRef<SWidget> SMarkdownWidget::BuildHorizontalRule()
+{
+    return SNew(SSeparator)
+    .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.2f, 0.25f, 0.8f)));
+}
+
+TSharedRef<SWidget> SMarkdownWidget::BuildInlineText(const FMarkdownElement& Element)
+{
+    switch (Element.Type)
+    {
+        case EMarkdownElementType::Bold:
+            return SNew(STextBlock)
+                .Text(FText::FromString(Element.Content))
+                .Font(FCoreStyle::GetDefaultFontStyle("Bold", NormalTextSize))
+                .ColorAndOpacity(FSlateColor(FLinearColor::White))
+                .AutoWrapText(true);
+
+        case EMarkdownElementType::Italic:
+            return SNew(STextBlock)
+                .Text(FText::FromString(Element.Content))
+                .Font(FCoreStyle::GetDefaultFontStyle("Italic", NormalTextSize))
+                .ColorAndOpacity(FSlateColor(FLinearColor::White))
+                .AutoWrapText(true);
+
+        case EMarkdownElementType::BoldItalic:
+            return SNew(STextBlock)
+                .Text(FText::FromString(Element.Content))
+                .Font(FCoreStyle::GetDefaultFontStyle("BoldItalic", NormalTextSize))
+                .ColorAndOpacity(FSlateColor(FLinearColor::White))
+                .AutoWrapText(true);
+
+        case EMarkdownElementType::InlineCode:
+            return SNew(SBorder)
+                .BorderImage(FAppStyle::GetBrush("ToolPanel.DarkGroupBorder"))
+                .BorderBackgroundColor(CodeBackgroundColor)
+                .Padding(FMargin(2.0f, 1.0f))
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(Element.Content))
+                    .Font(FCoreStyle::GetDefaultFontStyle("Mono", CodeTextSize))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.8f, 0.85f, 0.75f)))
+                ];
+
+        case EMarkdownElementType::Link:
+            return BuildLink(Element);
+
+        default:
+            return SNew(STextBlock)
+                .Text(FText::FromString(Element.Content))
+                .TextStyle(FAppStyle::Get(), "NormalText")
+                .AutoWrapText(true);
+    }
+}
+
+// ============================================================================
+// FMarkdownParser Helpers
+// ============================================================================
+
+bool FMarkdownParser::IsHeading(const FString& Line, int32& OutLevel, FString& OutContent)
+{
+    FString Trimmed = Line.TrimStart();
+
+    // Count leading #
+    int32 Level = 0;
+    int32 Pos = 0;
+    while (Pos < Trimmed.Len() && Trimmed[Pos] == '#')
+    {
+        Level++;
+        Pos++;
+    }
+
+    // Must have 1-4 # followed by space
+    if (Level >= 1 && Level <= 4 && Pos < Trimmed.Len() && Trimmed[Pos] == ' ')
+    {
+        OutLevel = Level;
+        OutContent = Trimmed.RightChop(Pos + 1).TrimStartAndEnd();
+        return true;
+    }
+
+    return false;
+}
+
+bool FMarkdownParser::IsCodeFence(const FString& Line, bool& bIsOpening, FString& OutLang)
+{
+    FString Trimmed = Line.TrimStartAndEnd();
+
+    if (!Trimmed.StartsWith(TEXT("```")))
+    {
+        return false;
+    }
+
+    bIsOpening = !Trimmed.EndsWith(TEXT("```")) || Trimmed.Len() > 3;
+    OutLang = Trimmed.RightChop(3).TrimStartAndEnd();
+    return true;
+}
+
+bool FMarkdownParser::IsBulletList(const FString& Line, FString& OutContent, int32& OutIndent)
+{
+    FString Trimmed = Line.TrimStart();
+
+    // Count indentation (spaces before marker)
+    OutIndent = Line.Len() - Trimmed.Len();
+
+    // Check for - or * followed by space
+    if (Trimmed.Len() > 1 && (Trimmed[0] == '-' || Trimmed[0] == '*') && Trimmed[1] == ' ')
+    {
+        // Make sure it's not a horizontal rule or italic
+        FString Rest = Trimmed.RightChop(1).TrimStartAndEnd();
+        if (!Rest.IsEmpty() && Rest != TEXT("---") && Rest != TEXT("***"))
+        {
+            OutContent = Trimmed.RightChop(2).TrimStart();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool FMarkdownParser::IsNumberedList(const FString& Line, FString& OutContent, int32& OutNumber, int32& OutIndent)
+{
+    FString Trimmed = Line.TrimStart();
+
+    // Count indentation
+    OutIndent = Line.Len() - Trimmed.Len();
+
+    // Find number followed by . and space
+    int32 DotPos = Trimmed.Find(TEXT(". "));
+    if (DotPos > 0)
+    {
+        FString NumberPart = Trimmed.Left(DotPos);
+        if (NumberPart.IsNumeric())
+        {
+            OutNumber = FCString::Atoi(*NumberPart);
+            OutContent = Trimmed.RightChop(DotPos + 2);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool FMarkdownParser::IsBlockQuote(const FString& Line, FString& OutContent)
+{
+    FString Trimmed = Line.TrimStart();
+
+    if (Trimmed.StartsWith(TEXT(">")))
+    {
+        OutContent = Trimmed.RightChop(1).TrimStart();
+        return true;
+    }
+
+    return false;
+}
+
+bool FMarkdownParser::IsHorizontalRule(const FString& Line)
+{
+    FString Trimmed = Line.TrimStartAndEnd();
+
+    // Must be at least 3 chars: ---, ***, ___
+    if (Trimmed.Len() < 3)
+    {
+        return false;
+    }
+
+    bool bAllDash = true;
+    bool bAllStar = true;
+    bool bAllUnderscore = true;
+
+    for (int32 i = 0; i < Trimmed.Len(); ++i)
+    {
+        if (Trimmed[i] != '-') bAllDash = false;
+        if (Trimmed[i] != '*') bAllStar = false;
+        if (Trimmed[i] != '_') bAllUnderscore = false;
+    }
+
+    return bAllDash || bAllStar || bAllUnderscore;
+}
+
+FString SMarkdownWidget::GetRenderedText() const
+{
+    // Return the raw markdown text for now
+    // In a more complex implementation, we could strip markdown markers
+    return MarkdownText;
+}
+
+FString SMarkdownWidget::GetPlainText() const
+{
+    // Return the full markdown text with all formatting markers intact
+    // This allows users to copy the exact markdown source
+    return MarkdownText;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/UnrealClaude/Source/UnrealClaude/Private/Widgets/SMarkdownWidget.h
+++ b/UnrealClaude/Source/UnrealClaude/Private/Widgets/SMarkdownWidget.h
@@ -1,0 +1,234 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Styling/SlateTypes.h"
+
+class SVerticalBox;
+class SHorizontalBox;
+class SHyperlink;
+class SMultiLineEditableText;
+class ITextDecorator;
+class SHorizontalBox;
+class SHyperlink;
+class SMultiLineEditableText;
+
+DECLARE_DELEGATE(FOnCopyAction)
+
+/**
+ * Markdown element types
+ */
+enum class EMarkdownElementType : uint8
+{
+    Paragraph,      // 普通文本段落
+    Heading1,       // # 标题
+    Heading2,       // ## 标题
+    Heading3,       // ### 标题
+    Heading4,       // #### 标题
+    CodeBlock,      // ``` 代码块
+    InlineCode,     // ` 行内代码
+    Bold,           // **bold**
+    Italic,         // *italic*
+    BoldItalic,     // ***bold italic***
+    BulletList,     // - 或 * 无序列表项
+    NumberedList,   // 1. 有序列表项
+    Link,           // [text](url)
+    HorizontalRule, // --- 分隔线
+    BlockQuote,     // > 引用块
+    Table,          // 表格（简化处理）
+    Image           // ![alt](url) - 显示 alt 文本
+};
+
+/**
+ * A parsed markdown element
+ */
+struct FMarkdownElement
+{
+    EMarkdownElementType Type;
+    FString Content;            // 文本内容
+    FString Url;                // 链接 URL（仅 Link 类型）
+    int32 Level = 0;            // 标题级别或列表序号
+    TArray<FMarkdownElement> Children;  // 子元素（用于嵌套格式）
+    TArray<TArray<FString>> TableRows;  // 表格数据（仅 Table 类型）
+
+    FMarkdownElement() = default;
+    FMarkdownElement(EMarkdownElementType InType, const FString& InContent)
+        : Type(InType), Content(InContent) {}
+};
+
+/**
+ * Markdown parser and renderer for Slate
+ *
+ * Supported elements:
+ * - Headings: # ## ### ####
+ * - Bold: **text** or __text__
+ * - Italic: *text* or _text_
+ * - Inline code: `code`
+ * - Code blocks: ``` with language tag
+ * - Bullet lists: - or *
+ * - Numbered lists: 1. 2. etc.
+ * - Links: [text](url)
+ * - Block quotes: >
+ * - Horizontal rules: ---
+ * - Tables: basic support
+ */
+class SMarkdownWidget : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SMarkdownWidget)
+        : _Text("")
+        , _bDarkTheme(true)
+    {}
+        SLATE_ARGUMENT(FString, Text)
+        SLATE_ARGUMENT(bool, bDarkTheme)  // 深色主题适配
+        SLATE_ATTRIBUTE(bool, bSelectionMode)  // 外部控制的选择模式（动态属性）
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs);
+
+    /** Set new markdown text (rebuilds the widget) */
+    void SetText(const FString& NewText);
+
+    /** Get the raw markdown text */
+    FString GetText() const { return MarkdownText; }
+
+    /** Get the rendered text (without markdown markers) */
+    FString GetRenderedText() const;
+
+    /** Get plain text for selection mode (strips markdown formatting markers) */
+    FString GetPlainText() const;
+
+    /** Parse markdown text into elements */
+    static TArray<FMarkdownElement> ParseMarkdown(const FString& MarkdownText);
+
+    /** Build Slate widgets from parsed elements */
+    TSharedRef<SWidget> BuildWidgetsFromElements(const TArray<FMarkdownElement>& Elements);
+
+private:
+    /** Rebuild the entire widget from current text */
+    void RebuildWidget();
+
+    /** Parse a single line into elements */
+    void ParseLine(const FString& Line, TArray<FMarkdownElement>& OutElements, int32& ListCounter, bool bInBlockQuote);
+
+    /** Parse inline formatting (bold, italic, code, links) within text */
+    static TArray<FMarkdownElement> ParseInlineFormatting(const FString& Text);
+
+    /** Build a paragraph widget with inline formatting */
+    TSharedRef<SWidget> BuildParagraph(const FMarkdownElement& Element);
+
+    /** Build a heading widget */
+    TSharedRef<SWidget> BuildHeading(const FMarkdownElement& Element);
+
+    /** Build a code block widget */
+    TSharedRef<SWidget> BuildCodeBlock(const FMarkdownElement& Element);
+
+    /** Build a list item widget */
+    TSharedRef<SWidget> BuildListItem(const FMarkdownElement& Element, int32 IndentLevel);
+
+    /** Build a link widget */
+    TSharedRef<SWidget> BuildLink(const FMarkdownElement& Element);
+
+    /** Build a block quote widget */
+    TSharedRef<SWidget> BuildBlockQuote(const FMarkdownElement& Element);
+
+    /** Build a table widget using SGridPanel */
+    TSharedRef<SWidget> BuildTable(const FMarkdownElement& Element);
+
+    /** Build rich text markup for a table cell */
+    FString BuildCellMarkup(const FString& CellText, bool bIsHeader, const TArray<TSharedRef<ITextDecorator>>& Decorators);
+
+    /** Build a horizontal rule widget */
+    TSharedRef<SWidget> BuildHorizontalRule();
+
+    /** Check if a line is a table row (starts and ends with |) */
+    static bool IsTableRow(const FString& Line);
+
+    /** Check if a line is a table separator (|---|---|) */
+    static bool IsTableSeparator(const FString& Line);
+
+    /** Parse table row into cell contents */
+    static TArray<FString> ParseTableRowCells(const FString& Line);
+
+    /** Build an inline formatted text segment */
+    TSharedRef<SWidget> BuildInlineText(const FMarkdownElement& Element);
+
+    /** Create a text run with specific styling */
+    TSharedPtr<STextBlock> CreateTextRun(
+        const FString& Text,
+        bool bBold = false,
+        bool bItalic = false,
+        bool bCode = false,
+        const FSlateColor& Color = FSlateColor(FLinearColor::White));
+
+private:
+    FString MarkdownText;
+    bool bDarkTheme = true;
+    TAttribute<bool> bSelectionModeAttr;  // Dynamic attribute for selection mode
+
+    /** Container for all rendered elements */
+    TSharedPtr<SVerticalBox> ContentBox;
+
+    /** Selectable text box for selection mode */
+    TSharedPtr<SMultiLineEditableText> SelectableTextBox;
+
+    /** Styling constants */
+    static constexpr float Heading1Size = 20.0f;
+    static constexpr float Heading2Size = 16.0f;
+    static constexpr float Heading3Size = 14.0f;
+    static constexpr float Heading4Size = 12.0f;
+    static constexpr float NormalTextSize = 10.0f;
+    static constexpr float CodeTextSize = 9.0f;
+
+    static const FLinearColor HeadingColor;
+    static const FLinearColor LinkColor;
+    static const FLinearColor CodeBackgroundColor;
+    static const FLinearColor QuoteBackgroundColor;
+    static const FLinearColor QuoteAccentColor;
+
+    // Static text styles for headings (needed for SRichTextBlock which takes style pointers)
+    static const FTextBlockStyle Heading1Style;
+    static const FTextBlockStyle Heading2Style;
+    static const FTextBlockStyle Heading3Style;
+    static const FTextBlockStyle Heading4Style;
+};
+
+/**
+ * Helper class for parsing markdown text
+ */
+class FMarkdownParser
+{
+public:
+    /** Parse full markdown document */
+    static TArray<FMarkdownElement> Parse(const FString& Markdown);
+
+    /** Parse a single line */
+    static FMarkdownElement ParseLine(const FString& Line, int32& OutListCounter, bool& bInCodeBlock, FString& CodeBlockLang);
+
+    /** Parse inline formatting within a text segment */
+    static TArray<FMarkdownElement> ParseInline(const FString& Text);
+
+    /** Check if line is a heading */
+    static bool IsHeading(const FString& Line, int32& OutLevel, FString& OutContent);
+
+    /** Check if line is a code block fence */
+    static bool IsCodeFence(const FString& Line, bool& bIsOpening, FString& OutLang);
+
+    /** Check if line is a bullet list item */
+    static bool IsBulletList(const FString& Line, FString& OutContent, int32& OutIndent);
+
+    /** Check if line is a numbered list item */
+    static bool IsNumberedList(const FString& Line, FString& OutContent, int32& OutNumber, int32& OutIndent);
+
+    /** Check if line is a block quote */
+    static bool IsBlockQuote(const FString& Line, FString& OutContent);
+
+    /** Check if line is a horizontal rule */
+    static bool IsHorizontalRule(const FString& Line);
+
+    /** Strip inline formatting markers, returning segments */
+    static TArray<TPair<FString, EMarkdownElementType>> StripInlineMarkers(const FString& Text);
+};

--- a/UnrealClaude/Source/UnrealClaude/Public/ClaudeEditorWidget.h
+++ b/UnrealClaude/Source/UnrealClaude/Public/ClaudeEditorWidget.h
@@ -12,21 +12,57 @@ class SScrollBox;
 class SVerticalBox;
 class SClaudeInputArea;
 class SExpandableArea;
+class SMarkdownWidget;
 
 /**
- * Chat message display widget
+ * Helper widget that wraps a scroll box and provides right-click drag scrolling
+ */
+class SRightClickDragBox : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SRightClickDragBox)
+	{}
+		SLATE_ARGUMENT(TSharedPtr<SScrollBox>, ScrollBox)
+		SLATE_DEFAULT_SLOT(FArguments, Content)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+	virtual FReply OnMouseButtonDown(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;
+	virtual FReply OnMouseButtonUp(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;
+	virtual FReply OnMouseMove(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;
+	virtual FReply OnMouseWheel(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;
+	virtual TOptional<EMouseCursor::Type> GetCursor() const override;
+
+private:
+	TSharedPtr<SScrollBox> TargetScrollBox;
+	bool bIsDragging = false;
+	FVector2D DragStartMousePos;
+	float DragStartScrollOffset = 0.0f;
+};
+
+/**
+ * Chat message display widget with optional Markdown rendering
  */
 class SChatMessage : public SCompoundWidget
 {
 public:
 	SLATE_BEGIN_ARGS(SChatMessage)
 		: _IsUser(true)
+		, _bRenderMarkdown(true)
 	{}
 		SLATE_ARGUMENT(FString, Message)
 		SLATE_ARGUMENT(bool, IsUser)
+		SLATE_ARGUMENT(bool, bRenderMarkdown)
+		SLATE_ATTRIBUTE(bool, bSelectionMode)
 	SLATE_END_ARGS()
 
 	void Construct(const FArguments& InArgs);
+
+private:
+	TSharedPtr<SMarkdownWidget> MarkdownWidget;
+	bool bUseMarkdown = true;
+	TAttribute<bool> bSelectionModeAttr;
 };
 
 /**
@@ -94,6 +130,12 @@ private:
 
 	/** Input area widget */
 	TSharedPtr<SClaudeInputArea> InputArea;
+
+	/** Stored Claude message widgets for updating selection mode */
+	TArray<TSharedPtr<SMarkdownWidget>> ClaudeMessageWidgets;
+
+	/** Stored message texts for rebuilding on mode change */
+	TArray<TPair<FString, bool>> MessageHistory;  // Message text + IsUser flag
 
 	/** Current input text */
 	FString CurrentInputText;
@@ -170,6 +212,9 @@ private:
 	/** Include project context in prompts */
 	bool bIncludeProjectContext = true;
 
+	/** Selection mode for Claude responses (true = plain text for copying) */
+	bool bSelectionMode = false;
+
 	/** Handle streaming progress from Claude (legacy, still used for accumulation) */
 	void OnClaudeProgress(const FString& PartialOutput);
 
@@ -217,4 +262,13 @@ private:
 
 	/** Generate MCP tool status message for greeting */
 	FString GenerateMCPStatusMessage() const;
+
+	/** Rebuild all chat messages with current selection mode */
+	void RebuildChatMessages();
+
+	/** Check if scroll box is at or near the bottom */
+	bool IsScrolledToBottom() const;
+
+	/** Scroll to end (use when user was at bottom before content update) */
+	void ScrollToEnd();
 };


### PR DESCRIPTION
Support Markdown display with code blocks and tables. 
Plain Text button to display and select text, as Claude and I have not find out how to select Markdown text. 
Right click and drag to scroll the panel up and down.
<img width="2020" height="1759" alt="屏幕截图 2026-04-29 100033" src="https://github.com/user-attachments/assets/7af235eb-8558-4377-b291-ac80125ff0fa" />
