### PR TITLE
feat: add Auto-approve script execution project setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,14 @@ The MCP bridge includes a dynamic context loader that provides accurate UE 5.7 A
 
 ## Configuration
 
+### Project Settings
+
+In **Project Settings → Plugins → Unreal Claude**:
+
+- **Auto-approve script execution** (default: OFF) — when ON, every Python / C++ / Console / Editor Utility script triggered through the MCP bridge or the in-editor chat runs immediately without showing the permission dialog. Each auto-approved script writes a `LogUnrealClaude` Log entry with its type and description so the audit trail is preserved. Designed for trusted MCP-driven / agent-driven workflows where the per-script confirmation becomes dominant friction; **only enable on machines and projects where the connected client is trusted**.
+
+The setting is persisted to `Config/DefaultEditor.ini` under `[/Script/UnrealClaude.UnrealClaudeSettings]`.
+
 ### Custom System Prompts
 
 You can extend the built-in UE5.7 context by creating a `CLAUDE.md` file in your project root:

--- a/UnrealClaude/Source/UnrealClaude/Private/ScriptExecutionManager.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ScriptExecutionManager.cpp
@@ -3,6 +3,7 @@
 #include "ScriptExecutionManager.h"
 #include "ScriptPermissionDialog.h"
 #include "UnrealClaudeModule.h"
+#include "UnrealClaudeSettings.h"
 #include "UnrealClaudeUtils.h"
 #include "JsonUtils.h"
 #include "MCP/MCPParamValidator.h"
@@ -92,6 +93,20 @@ bool FScriptExecutionManager::ShowPermissionDialog(
 	EScriptType Type,
 	const FString& Description)
 {
+	// Honour the project-level auto-approve setting, intended for trusted MCP/agent-driven workflows
+	// where the per-script confirmation is the dominant friction. Default OFF preserves the safe
+	// "human in the loop" behaviour. We log every auto-approval so the audit trail survives.
+	if (const UUnrealClaudeSettings* Settings = GetDefault<UUnrealClaudeSettings>())
+	{
+		if (Settings->bAutoApproveScripts)
+		{
+			UE_LOG(LogUnrealClaude, Log,
+				TEXT("Script auto-approved (bAutoApproveScripts=true). Type=%s Description=%s"),
+				*ScriptTypeToString(Type), *Description);
+			return true;
+		}
+	}
+
 	// Delegate to the extracted permission dialog class
 	return FScriptPermissionDialog::Show(ScriptPreview, Type, Description);
 }

--- a/UnrealClaude/Source/UnrealClaude/Public/UnrealClaudeSettings.h
+++ b/UnrealClaude/Source/UnrealClaude/Public/UnrealClaudeSettings.h
@@ -1,0 +1,48 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "UnrealClaudeSettings.generated.h"
+
+/**
+ * Project-level settings for the UnrealClaude plugin.
+ *
+ * Edit in: Project Settings -> Plugins -> Unreal Claude.
+ * Stored in: Config/DefaultEditor.ini under [/Script/UnrealClaude.UnrealClaudeSettings].
+ */
+UCLASS(Config=Editor, DefaultConfig, meta=(DisplayName="Unreal Claude"))
+class UNREALCLAUDE_API UUnrealClaudeSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+
+public:
+	UUnrealClaudeSettings() = default;
+
+	/**
+	 * Auto-approve all script execution requests instead of showing the per-call permission dialog.
+	 *
+	 * When OFF (default), every Python / C++ / Console / Editor Utility script triggered through the
+	 * MCP bridge or the in-editor Claude Assistant chat must be approved by the user via a modal dialog.
+	 * That is the safest default and matches the existing behaviour.
+	 *
+	 * Turn ON to opt into a "trusted" workflow where the host (Claude Code session, an MCP-driven agent,
+	 * or an automated test harness) drives many scripts in sequence and the per-script confirmation is
+	 * the dominant friction. Approvals are skipped silently and an INFO log line is written instead so
+	 * the audit trail is preserved.
+	 *
+	 * WARNING: enabling this means every script the connected agent submits runs immediately without
+	 * human confirmation. Only enable on machines and projects where the connected agent is trusted.
+	 */
+	UPROPERTY(EditAnywhere, Config, Category="Scripts", meta=(DisplayName="Auto-approve script execution"))
+	bool bAutoApproveScripts = false;
+
+	// UDeveloperSettings overrides
+
+	virtual FName GetCategoryName() const override { return TEXT("Plugins"); }
+
+#if WITH_EDITOR
+	virtual FText GetSectionText() const override { return NSLOCTEXT("UnrealClaude", "SettingsSectionText", "Unreal Claude"); }
+#endif
+};

--- a/UnrealClaude/Source/UnrealClaude/UnrealClaude.Build.cs
+++ b/UnrealClaude/Source/UnrealClaude/UnrealClaude.Build.cs
@@ -39,6 +39,8 @@ public class UnrealClaude : ModuleRules
 		PrivateDependencyModuleNames.AddRange(
 			new string[]
 			{
+				// Project Settings -> Plugins -> Unreal Claude (UUnrealClaudeSettings)
+				"DeveloperSettings",
 				"Json",
 				"JsonUtilities",
 				"HTTP",


### PR DESCRIPTION
# Add `bAutoApproveScripts` project setting

## What this adds

A new project-level toggle, **Project Settings → Plugins → Unreal Claude → Auto-approve script execution**, that bypasses the per-script permission dialog when ON.

- New file: `UnrealClaude/Source/UnrealClaude/Public/UnrealClaudeSettings.h` — a small `UDeveloperSettings` exposing one `bool bAutoApproveScripts` (default `false`).
- `ScriptExecutionManager::ShowPermissionDialog` short-circuits to `return true` when the setting is ON, after writing one `LogUnrealClaude` Log entry recording the script type and description so the audit trail survives.
- `UnrealClaude.Build.cs` adds `DeveloperSettings` to `PrivateDependencyModuleNames`.
- `README.md` "Configuration" section documents the toggle.

## Why

When a Claude Code session (or any MCP client) drives the `unrealclaude-mcp-bridge` through many short scripted steps in a row — teleporting actors, sampling stats, running console commands programmatically — every script triggers a modal dialog the user must click through. For agent-driven workflows the dialog becomes the dominant cost: a 10-step orchestration is 10 manual clicks even though the human has already told the agent "go do this".

The default-OFF design preserves the existing safe behaviour for everyone who hasn't opted in. The opt-in is **explicitly named, persisted to `Config/DefaultEditor.ini` under `[/Script/UnrealClaude.UnrealClaudeSettings]`**, and the README warns about the trust implications.

## What this is NOT

- **Not a CVar.** Discoverable UI in Project Settings is the right home for a trust toggle, not a hidden console command.
- **Not a per-script bypass.** All scripts auto-approve or none — keeping the contract simple.
- **Not a refactor of the modal.** The dialog code path is untouched on the OFF path. The bypass is a single check at the entry point of `ShowPermissionDialog`.

## Trust model

Each auto-approval logs a line like:
```
LogUnrealClaude: Script auto-approved (bAutoApproveScripts=true). Type=EScriptType::Python Description=Teleport player to test pose
```
Combined with the existing `Saved/UnrealClaude/` script-history persistence, an operator can audit exactly what was executed in any given session.

## Tested

- Built against UE 5.7, macOS / Apple Silicon, with both states of the toggle.
- ON: scripts dispatched via the MCP bridge run immediately; one Log line per execution.
- OFF: behaviour identical to current `master` (modal dialog with Approve / Deny buttons).

## Out of scope (possible follow-ups)

- A "remember for this session" checkbox inside the dialog itself (would set the project setting at runtime).
- Per-script-type granularity (e.g. allow Python but always confirm C++).
- A confirm-once-per-MCP-client trust handshake.

I'd rather ship the simple toggle now and iterate based on how it gets used.
