### PR TITLE
fix(mcp): emit canonical isError field; standardize HTTP error envelope

### DIFF
--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/UnrealClaudeMCPServer.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/UnrealClaudeMCPServer.cpp
@@ -247,9 +247,12 @@ bool FUnrealClaudeMCPServer::HandleExecuteTool(const FHttpServerRequest& Request
 
 	FMCPToolResult Result = ToolRegistry->ExecuteTool(ToolName, ParamsJson.ToSharedRef());
 
-	// Build response
+	// Build response. `isError` is the canonical MCP field
+	// (https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling);
+	// `success` is retained for the legacy bridge contract.
 	TSharedPtr<FJsonObject> ResponseJson = MakeShared<FJsonObject>();
 	ResponseJson->SetBoolField(TEXT("success"), Result.bSuccess);
+	ResponseJson->SetBoolField(TEXT("isError"), !Result.bSuccess);
 	ResponseJson->SetStringField(TEXT("message"), Result.Message);
 
 	if (Result.Data.IsValid())
@@ -328,6 +331,10 @@ TUniquePtr<FHttpServerResponse> FUnrealClaudeMCPServer::CreateErrorResponse(cons
 {
 	TSharedPtr<FJsonObject> ErrorJson = MakeShared<FJsonObject>();
 	ErrorJson->SetBoolField(TEXT("success"), false);
+	ErrorJson->SetBoolField(TEXT("isError"), true);
+	ErrorJson->SetStringField(TEXT("message"), Message);
+	// `error` is kept as a deprecation grace period for any direct HTTP consumer
+	// that was reading the old field name. The bridge has always read `message`.
 	ErrorJson->SetStringField(TEXT("error"), Message);
 
 	FString JsonString;


### PR DESCRIPTION
## Summary

Two convergent fixes, motivated by Epic's MCP plugin landing on `dev-5.8` and exposing the canonical envelope shape they'll target.

**C++ envelope** (`UnrealClaudeMCPServer.cpp`):
- `HandleExecuteTool` now emits the canonical MCP 2025-06-18 `isError` boolean alongside the legacy `success` field. The two are kept in sync (`isError == !success`).
- `CreateErrorResponse` (HTTP-level failures: bad tool name, request body too large, malformed JSON body) now sets the `message` field too. Previously only `error` was set — and the bridge has always read `message`, so HTTP-level errors silently rendered as `Error: undefined` in the LLM context. `error` is retained as a one-release deprecation grace period for any direct HTTP consumer.

**Bridge** (`Resources/mcp-bridge` → bumped to [`f829a5e`](https://github.com/Natfii/ue5-mcp-bridge/commit/f829a5e)):
- `formatToolResponse` prefers `result.isError` when present (boolean), falls back to `!result.success` for older plugin versions.
- Defensive `"Unknown error"` fallback for any error result that lacks a `message` field.
- 8 new unit tests in `tests/unit/format-tool-response.test.js`.

## Test plan

- [x] All 182 bridge vitest tests pass (8 new + 174 unchanged, no regressions)
- [x] Plugin builds clean via `RunUAT BuildPlugin` (UE 5.7)
- [x] Smoke test in editor: `unreal_spawn_actor` with bogus class renders **`Error: Could not find actor class: /Script/Engine.ThisClassDoesNotExist_SmokeTest`** (clean message, no `undefined`) and Claude Code's MCP client honors `isError: true` by surfacing the response inside an `<error>` block
- [x] Audit confirms no internal C++ consumer reads `error` from the HTTP envelope (the `error` field hits in `AnimationBlueprintUtils` are inside tool `Data` payloads, unrelated to the HTTP envelope)

## Follow-up

When PR 2 lands (typed result content: `Text`/`Image`/`Audio`/`StructuredContent`), the envelope-building inline in `HandleExecuteTool` / `CreateErrorResponse` should be extracted into `UnrealClaude::MCP::BuildToolResultJson` and `BuildErrorEnvelopeJson` free functions. That extraction unlocks C++ unit tests asserting envelope shape directly. Deferred from this PR because the surface is small and bridge tests + smoke test cover it for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)