### PR TITLE
feat(mcp): typed result content + BuildToolResultJson formatter extraction

### DIFF
--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/MCPResponseFormatter.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/MCPResponseFormatter.cpp
@@ -1,0 +1,81 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#include "MCPResponseFormatter.h"
+#include "MCPToolRegistry.h"
+
+namespace UnrealClaude::MCP
+{
+	TSharedPtr<FJsonObject> BuildToolResultJson(const FMCPToolResult& Result)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+
+		// Canonical MCP 2025-06-18 fields + legacy `success` for bridge compatibility.
+		Json->SetBoolField(TEXT("success"), Result.bSuccess);
+		Json->SetBoolField(TEXT("isError"), !Result.bSuccess);
+		Json->SetStringField(TEXT("message"), Result.Message);
+
+		Json->SetStringField(TEXT("contentType"), MCPToolResultTypeToString(Result.ContentType));
+
+		// Binary payload + MIME type only meaningful for Image/Audio.
+		if (Result.ContentType == EMCPToolResultType::Image ||
+			Result.ContentType == EMCPToolResultType::Audio)
+		{
+			if (!Result.MimeType.IsEmpty())
+			{
+				Json->SetStringField(TEXT("mimeType"), Result.MimeType);
+			}
+			if (!Result.Base64Payload.IsEmpty())
+			{
+				Json->SetStringField(TEXT("base64"), Result.Base64Payload);
+			}
+		}
+
+		if (Result.Data.IsValid())
+		{
+			Json->SetObjectField(TEXT("data"), Result.Data);
+		}
+
+		// Backward-compat shim: older bridge versions detect capture_viewport
+		// images via `data.image_base64`. Emit it alongside the canonical
+		// `base64` field for one release so old bridges keep working with
+		// new plugins. Bridges that understand `contentType` ignore this.
+		if (Result.ContentType == EMCPToolResultType::Image &&
+			!Result.Base64Payload.IsEmpty())
+		{
+			TSharedPtr<FJsonObject> DataForLegacy = Result.Data.IsValid()
+				? Result.Data
+				: MakeShared<FJsonObject>();
+			if (!DataForLegacy->HasField(TEXT("image_base64")))
+			{
+				DataForLegacy->SetStringField(TEXT("image_base64"), Result.Base64Payload);
+			}
+			Json->SetObjectField(TEXT("data"), DataForLegacy);
+		}
+
+		if (Result.Warnings.Num() > 0)
+		{
+			TArray<TSharedPtr<FJsonValue>> WarningsJson;
+			WarningsJson.Reserve(Result.Warnings.Num());
+			for (const FString& Warning : Result.Warnings)
+			{
+				WarningsJson.Add(MakeShared<FJsonValueString>(Warning));
+			}
+			Json->SetArrayField(TEXT("warnings"), WarningsJson);
+		}
+
+		return Json;
+	}
+
+	TSharedPtr<FJsonObject> BuildErrorEnvelopeJson(const FString& Message)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+		Json->SetBoolField(TEXT("success"), false);
+		Json->SetBoolField(TEXT("isError"), true);
+		Json->SetStringField(TEXT("message"), Message);
+		// `error` is a deprecated alias retained for one release; the bridge
+		// has always read `message`. Direct HTTP consumers that read `error`
+		// keep working.
+		Json->SetStringField(TEXT("error"), Message);
+		return Json;
+	}
+}

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/MCPResponseFormatter.h
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/MCPResponseFormatter.h
@@ -1,0 +1,48 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+
+struct FMCPToolResult;
+
+namespace UnrealClaude::MCP
+{
+	/**
+	 * Build the JSON envelope returned by POST /mcp/tool/{name} from an
+	 * FMCPToolResult. Caller is responsible for HTTP-level concerns
+	 * (status code, headers, serialization to string).
+	 *
+	 * Envelope shape:
+	 *   {
+	 *     "success":     bool,
+	 *     "isError":     bool                          // canonical MCP 2025-06-18 field
+	 *     "message":     string,
+	 *     "data":        object (optional),
+	 *     "warnings":    [string] (optional),
+	 *     "contentType": "text" | "image" | "audio" | "structured",
+	 *     "mimeType":    string (only when contentType is image/audio),
+	 *     "base64":      string (only when contentType is image/audio)
+	 *   }
+	 *
+	 * For backward compatibility with bridge versions that special-cased
+	 * capture_viewport via `data.image_base64`, image results also emit
+	 * the legacy `data.image_base64` field as a deprecation grace period.
+	 */
+	TSharedPtr<FJsonObject> BuildToolResultJson(const FMCPToolResult& Result);
+
+	/**
+	 * Build the JSON envelope returned by HTTP-level error responses
+	 * (bad tool name, oversized body, malformed JSON body).
+	 *
+	 * Envelope shape:
+	 *   {
+	 *     "success": false,
+	 *     "isError": true,
+	 *     "message": string,
+	 *     "error":   string   // deprecated alias of "message", retained for one release
+	 *   }
+	 */
+	TSharedPtr<FJsonObject> BuildErrorEnvelopeJson(const FString& Message);
+}

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/MCPToolRegistry.h
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/MCPToolRegistry.h
@@ -121,7 +121,44 @@ struct FMCPToolInfo
 };
 
 /**
- * Result from executing an MCP tool
+ * Tool result content type — mirrors the MCP 2025-06-18 content block taxonomy.
+ * Tools default to Text; capture-style tools opt into Image; Audio and
+ * StructuredContent are reserved for future use (enum values declared so
+ * we don't have to bump the API surface when the first consumer lands).
+ */
+enum class EMCPToolResultType : uint8
+{
+	/** Plain text payload (the default — Message + stringified Data). */
+	Text = 0,
+	/** Base64-encoded image. Bridge emits a native MCP image content block. */
+	Image,
+	/** Base64-encoded audio. Reserved — bridge falls back to text path until a consumer lands. */
+	Audio,
+	/** Top-level structured JSON payload. Reserved — bridge falls back to text path. */
+	StructuredContent
+};
+
+/** Stable lowercase serialization matching MCP spec content-block "type" values. */
+inline const TCHAR* MCPToolResultTypeToString(EMCPToolResultType InType)
+{
+	switch (InType)
+	{
+	case EMCPToolResultType::Image:             return TEXT("image");
+	case EMCPToolResultType::Audio:             return TEXT("audio");
+	case EMCPToolResultType::StructuredContent: return TEXT("structured");
+	case EMCPToolResultType::Text:              // fallthrough
+	default:                                    return TEXT("text");
+	}
+}
+
+/**
+ * Result from executing an MCP tool.
+ *
+ * Defaults to Text content (Message + stringified Data). Tools that produce
+ * non-text payloads should use the typed factories (FMCPToolResult::Image)
+ * instead of stuffing the payload into Data — that keeps the C++ side
+ * authoritative about the content type rather than requiring the bridge to
+ * string-match on toolName.
  */
 struct FMCPToolResult
 {
@@ -136,6 +173,15 @@ struct FMCPToolResult
 
 	/** Optional non-fatal warnings (e.g. unknown/deprecated parameter names) */
 	TArray<FString> Warnings;
+
+	/** Content type hint for the response formatter (default Text). */
+	EMCPToolResultType ContentType = EMCPToolResultType::Text;
+
+	/** MIME type for Image/Audio payloads (e.g. "image/jpeg"). Ignored for Text/StructuredContent. */
+	FString MimeType;
+
+	/** Base64-encoded binary payload for Image/Audio. Ignored for Text/StructuredContent. */
+	FString Base64Payload;
 
 	FMCPToolResult()
 		: bSuccess(false)
@@ -155,6 +201,30 @@ struct FMCPToolResult
 		FMCPToolResult Result;
 		Result.bSuccess = false;
 		Result.Message = InMessage;
+		return Result;
+	}
+
+	/**
+	 * Image content factory. The bridge will emit a native MCP image content
+	 * block ({type:"image", data:<base64>, mimeType:...}) plus a separate text
+	 * block carrying Message and the metadata Data object (without re-emitting
+	 * the base64 payload).
+	 *
+	 * @param InBase64    Base64-encoded image bytes (without data: URI prefix).
+	 * @param InMimeType  MIME type, e.g. "image/jpeg" or "image/png".
+	 * @param InMessage   Optional human-readable caption / status line.
+	 * @param InData      Optional metadata sidecar (width, height, viewport_type, etc.).
+	 */
+	static FMCPToolResult Image(const FString& InBase64, const FString& InMimeType,
+		const FString& InMessage = FString(), TSharedPtr<FJsonObject> InData = nullptr)
+	{
+		FMCPToolResult Result;
+		Result.bSuccess = true;
+		Result.Message = InMessage;
+		Result.Data = InData;
+		Result.ContentType = EMCPToolResultType::Image;
+		Result.MimeType = InMimeType;
+		Result.Base64Payload = InBase64;
 		return Result;
 	}
 };

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_CaptureViewport.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_CaptureViewport.cpp
@@ -113,9 +113,9 @@ FMCPToolResult FMCPTool_CaptureViewport::Execute(const TSharedRef<FJsonObject>& 
 	// Encode to base64
 	const FString Base64Image = FBase64::Encode(CompressedData.GetData(), CompressedData.Num());
 
-	// Build result JSON
+	// Sidecar metadata. image_base64 is no longer set here — BuildToolResultJson
+	// emits it as a backward-compat shim alongside the canonical `base64` field.
 	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
-	ResultData->SetStringField(TEXT("image_base64"), Base64Image);
 	ResultData->SetNumberField(TEXT("width"), TargetWidth);
 	ResultData->SetNumberField(TEXT("height"), TargetHeight);
 	ResultData->SetStringField(TEXT("format"), TEXT("jpeg"));
@@ -127,7 +127,9 @@ FMCPToolResult FMCPTool_CaptureViewport::Execute(const TSharedRef<FJsonObject>& 
 	UE_LOG(LogUnrealClaude, Log, TEXT("Captured %s viewport: %dx%d -> %dx%d JPEG (%d bytes base64)"),
 		*ViewportType, ViewportSize.X, ViewportSize.Y, TargetWidth, TargetHeight, Base64Image.Len());
 
-	return FMCPToolResult::Success(
+	return FMCPToolResult::Image(
+		Base64Image,
+		TEXT("image/jpeg"),
 		FString::Printf(TEXT("Captured %s viewport: %dx%d JPEG"), *ViewportType, TargetWidth, TargetHeight),
 		ResultData
 	);

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/UnrealClaudeMCPServer.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/UnrealClaudeMCPServer.cpp
@@ -2,6 +2,7 @@
 
 #include "UnrealClaudeMCPServer.h"
 #include "MCPToolRegistry.h"
+#include "MCPResponseFormatter.h"
 #include "UnrealClaudeModule.h"
 #include "UnrealClaudeConstants.h"
 #include "HttpServerModule.h"
@@ -247,25 +248,7 @@ bool FUnrealClaudeMCPServer::HandleExecuteTool(const FHttpServerRequest& Request
 
 	FMCPToolResult Result = ToolRegistry->ExecuteTool(ToolName, ParamsJson.ToSharedRef());
 
-	// Build response
-	TSharedPtr<FJsonObject> ResponseJson = MakeShared<FJsonObject>();
-	ResponseJson->SetBoolField(TEXT("success"), Result.bSuccess);
-	ResponseJson->SetStringField(TEXT("message"), Result.Message);
-
-	if (Result.Data.IsValid())
-	{
-		ResponseJson->SetObjectField(TEXT("data"), Result.Data);
-	}
-
-	if (Result.Warnings.Num() > 0)
-	{
-		TArray<TSharedPtr<FJsonValue>> WarningsJson;
-		for (const FString& Warning : Result.Warnings)
-		{
-			WarningsJson.Add(MakeShared<FJsonValueString>(Warning));
-		}
-		ResponseJson->SetArrayField(TEXT("warnings"), WarningsJson);
-	}
+	TSharedPtr<FJsonObject> ResponseJson = UnrealClaude::MCP::BuildToolResultJson(Result);
 
 	FString JsonString;
 	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&JsonString);
@@ -326,9 +309,7 @@ TUniquePtr<FHttpServerResponse> FUnrealClaudeMCPServer::CreateJsonResponse(const
 
 TUniquePtr<FHttpServerResponse> FUnrealClaudeMCPServer::CreateErrorResponse(const FString& Message, EHttpServerResponseCodes Code)
 {
-	TSharedPtr<FJsonObject> ErrorJson = MakeShared<FJsonObject>();
-	ErrorJson->SetBoolField(TEXT("success"), false);
-	ErrorJson->SetStringField(TEXT("error"), Message);
+	TSharedPtr<FJsonObject> ErrorJson = UnrealClaude::MCP::BuildErrorEnvelopeJson(Message);
 
 	FString JsonString;
 	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&JsonString);

--- a/UnrealClaude/Source/UnrealClaude/Private/Tests/MCPResponseFormatterTests.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/Tests/MCPResponseFormatterTests.cpp
@@ -1,0 +1,214 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+/**
+ * Unit tests for UnrealClaude::MCP response formatter helpers
+ * (BuildToolResultJson + BuildErrorEnvelopeJson).
+ *
+ * Asserts the JSON envelope shape returned by POST /mcp/tool/{name} for
+ * each FMCPToolResult content type, plus the dedicated HTTP-level error
+ * envelope. Locks in the contract the bridge depends on.
+ */
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Dom/JsonObject.h"
+#include "MCP/MCPResponseFormatter.h"
+#include "MCP/MCPToolRegistry.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+BEGIN_DEFINE_SPEC(
+	FMCPResponseFormatterSpec,
+	"UnrealClaude.MCP.ResponseFormatter",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FMCPResponseFormatterSpec)
+
+void FMCPResponseFormatterSpec::Define()
+{
+	using namespace UnrealClaude::MCP;
+
+	Describe(TEXT("BuildToolResultJson"), [this]()
+	{
+		Describe(TEXT("success result"), [this]()
+		{
+			It("emits success=true and isError=false", [this]()
+			{
+				const FMCPToolResult Result = FMCPToolResult::Success(TEXT("ok"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				bool bSuccess = false, bIsError = true;
+				TestTrue(TEXT("success field present"), Json->TryGetBoolField(TEXT("success"), bSuccess));
+				TestTrue(TEXT("isError field present"), Json->TryGetBoolField(TEXT("isError"), bIsError));
+				TestTrue(TEXT("success == true"), bSuccess);
+				TestFalse(TEXT("isError == false"), bIsError);
+			});
+
+			It("emits the message field", [this]()
+			{
+				const FMCPToolResult Result = FMCPToolResult::Success(TEXT("operation complete"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				FString Message;
+				TestTrue(TEXT("message field present"), Json->TryGetStringField(TEXT("message"), Message));
+				TestEqual(TEXT("message round-trip"), Message, TEXT("operation complete"));
+			});
+
+			It("defaults contentType to \"text\"", [this]()
+			{
+				const FMCPToolResult Result = FMCPToolResult::Success(TEXT("ok"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				FString ContentType;
+				TestTrue(TEXT("contentType field present"), Json->TryGetStringField(TEXT("contentType"), ContentType));
+				TestEqual(TEXT("contentType defaults to text"), ContentType, TEXT("text"));
+			});
+
+			It("omits mimeType and base64 for text results", [this]()
+			{
+				const FMCPToolResult Result = FMCPToolResult::Success(TEXT("ok"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				TestFalse(TEXT("no mimeType on text result"), Json->HasField(TEXT("mimeType")));
+				TestFalse(TEXT("no base64 on text result"), Json->HasField(TEXT("base64")));
+			});
+
+			It("includes the optional data object when provided", [this]()
+			{
+				const TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+				Data->SetStringField(TEXT("actor_name"), TEXT("BP_Enemy_42"));
+				const FMCPToolResult Result = FMCPToolResult::Success(TEXT("spawned"), Data);
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				const TSharedPtr<FJsonObject>* DataField = nullptr;
+				TestTrue(TEXT("data field present"), Json->TryGetObjectField(TEXT("data"), DataField));
+				FString ActorName;
+				TestTrue(TEXT("data.actor_name present"), (*DataField)->TryGetStringField(TEXT("actor_name"), ActorName));
+				TestEqual(TEXT("data.actor_name round-trip"), ActorName, TEXT("BP_Enemy_42"));
+			});
+
+			It("emits warnings array when warnings are present", [this]()
+			{
+				FMCPToolResult Result = FMCPToolResult::Success(TEXT("ok"));
+				Result.Warnings.Add(TEXT("deprecated param: asset_type"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				const TArray<TSharedPtr<FJsonValue>>* Warnings = nullptr;
+				TestTrue(TEXT("warnings array present"), Json->TryGetArrayField(TEXT("warnings"), Warnings));
+				TestEqual(TEXT("one warning"), Warnings->Num(), 1);
+				TestEqual(TEXT("warning round-trip"),
+					(*Warnings)[0]->AsString(), TEXT("deprecated param: asset_type"));
+			});
+
+			It("omits warnings field when none are present", [this]()
+			{
+				const FMCPToolResult Result = FMCPToolResult::Success(TEXT("ok"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				TestFalse(TEXT("no warnings field"), Json->HasField(TEXT("warnings")));
+			});
+		});
+
+		Describe(TEXT("error result"), [this]()
+		{
+			It("emits success=false and isError=true", [this]()
+			{
+				const FMCPToolResult Result = FMCPToolResult::Error(TEXT("something broke"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				bool bSuccess = true, bIsError = false;
+				Json->TryGetBoolField(TEXT("success"), bSuccess);
+				Json->TryGetBoolField(TEXT("isError"), bIsError);
+				TestFalse(TEXT("success == false"), bSuccess);
+				TestTrue(TEXT("isError == true"), bIsError);
+			});
+
+			It("preserves the error message", [this]()
+			{
+				const FMCPToolResult Result = FMCPToolResult::Error(TEXT("class not found: BogusActor"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				FString Message;
+				Json->TryGetStringField(TEXT("message"), Message);
+				TestEqual(TEXT("message round-trip"), Message, TEXT("class not found: BogusActor"));
+			});
+		});
+
+		Describe(TEXT("image result"), [this]()
+		{
+			It("emits contentType=\"image\"", [this]()
+			{
+				const FMCPToolResult Result = FMCPToolResult::Image(
+					TEXT("ZmFrZS1pbWFnZS1ieXRlcw=="), TEXT("image/png"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				FString ContentType;
+				Json->TryGetStringField(TEXT("contentType"), ContentType);
+				TestEqual(TEXT("contentType=image"), ContentType, TEXT("image"));
+			});
+
+			It("emits mimeType and base64 at top level", [this]()
+			{
+				const FMCPToolResult Result = FMCPToolResult::Image(
+					TEXT("ZmFrZS1pbWFnZS1ieXRlcw=="), TEXT("image/jpeg"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				FString MimeType, Base64;
+				TestTrue(TEXT("mimeType field present"), Json->TryGetStringField(TEXT("mimeType"), MimeType));
+				TestTrue(TEXT("base64 field present"), Json->TryGetStringField(TEXT("base64"), Base64));
+				TestEqual(TEXT("mimeType round-trip"), MimeType, TEXT("image/jpeg"));
+				TestEqual(TEXT("base64 round-trip"), Base64, TEXT("ZmFrZS1pbWFnZS1ieXRlcw=="));
+			});
+
+			It("mirrors base64 into data.image_base64 for backward compat", [this]()
+			{
+				const FMCPToolResult Result = FMCPToolResult::Image(
+					TEXT("Zg=="), TEXT("image/jpeg"));
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				const TSharedPtr<FJsonObject>* DataField = nullptr;
+				TestTrue(TEXT("data field present"), Json->TryGetObjectField(TEXT("data"), DataField));
+				FString LegacyBase64;
+				TestTrue(TEXT("data.image_base64 mirrored"),
+					(*DataField)->TryGetStringField(TEXT("image_base64"), LegacyBase64));
+				TestEqual(TEXT("data.image_base64 matches top-level"), LegacyBase64, TEXT("Zg=="));
+			});
+
+			It("preserves metadata sidecar data alongside the legacy image_base64 mirror", [this]()
+			{
+				const TSharedPtr<FJsonObject> Meta = MakeShared<FJsonObject>();
+				Meta->SetNumberField(TEXT("width"), 1024);
+				Meta->SetNumberField(TEXT("height"), 576);
+				const FMCPToolResult Result = FMCPToolResult::Image(
+					TEXT("Zg=="), TEXT("image/jpeg"), TEXT("captured"), Meta);
+				const TSharedPtr<FJsonObject> Json = BuildToolResultJson(Result);
+				const TSharedPtr<FJsonObject>* DataField = nullptr;
+				Json->TryGetObjectField(TEXT("data"), DataField);
+				double Width = 0.0;
+				TestTrue(TEXT("data.width preserved"), (*DataField)->TryGetNumberField(TEXT("width"), Width));
+				TestEqual(TEXT("data.width round-trip"), Width, 1024.0);
+				TestTrue(TEXT("data.image_base64 still mirrored"),
+					(*DataField)->HasField(TEXT("image_base64")));
+			});
+		});
+	});
+
+	Describe(TEXT("BuildErrorEnvelopeJson"), [this]()
+	{
+		It("emits success=false and isError=true", [this]()
+		{
+			const TSharedPtr<FJsonObject> Json = BuildErrorEnvelopeJson(TEXT("bad request"));
+			bool bSuccess = true, bIsError = false;
+			Json->TryGetBoolField(TEXT("success"), bSuccess);
+			Json->TryGetBoolField(TEXT("isError"), bIsError);
+			TestFalse(TEXT("success == false"), bSuccess);
+			TestTrue(TEXT("isError == true"), bIsError);
+		});
+
+		It("emits the message field", [this]()
+		{
+			const TSharedPtr<FJsonObject> Json = BuildErrorEnvelopeJson(TEXT("tool name not specified"));
+			FString Message;
+			Json->TryGetStringField(TEXT("message"), Message);
+			TestEqual(TEXT("message round-trip"), Message, TEXT("tool name not specified"));
+		});
+
+		It("emits the deprecated error alias matching message", [this]()
+		{
+			const TSharedPtr<FJsonObject> Json = BuildErrorEnvelopeJson(TEXT("invalid JSON body"));
+			FString Message, Error;
+			Json->TryGetStringField(TEXT("message"), Message);
+			Json->TryGetStringField(TEXT("error"), Error);
+			TestEqual(TEXT("error alias matches message"), Error, Message);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
## Summary

Mirrors Epic's MCP plugin design (`EModelContextProtocolToolResultType` in their `ModelContextProtocolToolResults.h`) for declaring tool result content type up front, instead of the bridge string-matching on toolName.

**Core changes:**
- New `EMCPToolResultType` enum (Text / Image / Audio / StructuredContent) on `FMCPToolResult`. Default `Text` — existing tools unaffected.
- New `FMCPToolResult::Image(base64, mimeType, message, metadata)` factory. `MCPTool_CaptureViewport` switches to use it.
- New `Source/UnrealClaude/Private/MCP/MCPResponseFormatter.{h,cpp}` exposing `UnrealClaude::MCP::BuildToolResultJson` and `BuildErrorEnvelopeJson`. `HandleExecuteTool` and `CreateErrorResponse` are now thin wrappers — fulfills the deferred follow-up from PR #35.
- New `MCPResponseFormatterTests.cpp` with 16 BDD-spec tests asserting envelope shape per content type.
- Bumps `Resources/mcp-bridge` to [`f10a465`](https://github.com/Natfii/ue5-mcp-bridge/commit/f10a465) — `formatToolResponse` now switches on `result.contentType` first, falls back to the legacy `toolName === "capture_viewport" && data.image_base64` path for older plugins. 6 new vitest tests cover the new dispatch.

**Why now:** Epic shipped this design on `dev-5.8`; matching their primitive sets us up to converge later if useful, and any future image/audio-producing tool no longer requires editing the bridge.

## Backward compatibility

The toolName-based image path on the bridge stayed in place, and the C++ formatter mirrors `base64` into `data.image_base64` for one release. Three permutations remain valid:

| Plugin | Bridge | Path |
|---|---|---|
| New | New | Canonical `contentType: "image"` + top-level `base64` |
| New | Old | Old bridge sees `data.image_base64` mirror; toolName-match dispatches image |
| Old | New | New bridge sees no `contentType`; toolName + `data.image_base64` legacy fallback |

The `data.image_base64` mirror should be removed in a future release once the bridge floor moves up.

## Test plan

- [x] All 16 `UnrealClaude.MCP.ResponseFormatter.*` tests pass (success path, error path, image path with backward-compat shim, error envelope)
- [x] Full automation suite green (`UnrealClaude.MCP.Tools.*`, `Registry.*`, `TaskQueue.*`, `ParamValidator.*`, `ClipboardImage.*`, `SilenceWatchdog.*`) — confirms the `FMCPToolResult` shape change doesn't disturb any existing tool
- [x] All 188 bridge vitest tests pass (6 new + 182 unchanged)
- [x] End-to-end smoke: `unreal_capture_viewport` renders inline as a native MCP image block, metadata visible in a separate text block (`width: 1024, height: 576, format: jpeg, viewport_type: Editor`), no base64 leakage, actual scene content intact

## Follow-up

Backward-compat verification of the old-bridge / new-plugin permutation by temporarily downgrading the bridge submodule and re-running `capture_viewport` in editor. Will land separately if anything surfaces.

## Relationship to PR #35

Both PRs touch `UnrealClaudeMCPServer.cpp` and the `Resources/mcp-bridge` submodule pointer. The new `BuildToolResultJson` formatter here naturally subsumes PR #35's inline `isError`/`message` additions — whichever lands first, the other will need a trivial merge resolution (take the formatter-based version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)