### PR TITLE
feat: add copy button functionality to chat messages

### DIFF
--- a/UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp
@@ -26,6 +26,7 @@
 #include "Widgets/SBoxPanel.h"
 #include "Styling/AppStyle.h"
 #include "Styling/CoreStyle.h"
+#include "Framework/Application/SlateApplication.h"
 #include "HAL/PlatformApplicationMisc.h"
 
 #define LOCTEXT_NAMESPACE "UnrealClaude"
@@ -188,10 +189,26 @@ void SChatMessage::Construct(const FArguments& InArgs)
 				.AutoHeight()
 				.Padding(0, 0, 0, 6)
 				[
-					SNew(STextBlock)
-					.Text(FText::FromString(RoleLabel))
-					.TextStyle(FAppStyle::Get(), "SmallText")
-					.ColorAndOpacity(FSlateColor(RoleLabelColor))
+					SNew(SHorizontalBox)
+
+					+ SHorizontalBox::Slot()
+					.FillWidth(1.0f)
+					.VAlign(VAlign_Center)
+					[
+						SNew(STextBlock)
+						.Text(FText::FromString(RoleLabel))
+						.TextStyle(FAppStyle::Get(), "SmallText")
+						.ColorAndOpacity(FSlateColor(RoleLabelColor))
+					]
+
+					// Per-message copy button (on both user and Claude messages)
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					[
+						SNew(SCopyButton)
+						.OnGetText_Lambda([Message]() { return Message; })
+					]
 				]
 
 				+ SVerticalBox::Slot()
@@ -202,6 +219,67 @@ void SChatMessage::Construct(const FArguments& InArgs)
 			]
 		]
 	];
+}
+
+// ============================================================================
+// SCopyButton
+// ============================================================================
+
+void SCopyButton::Construct(const FArguments& InArgs)
+{
+	OnGetTextDelegate = InArgs._OnGetText;
+
+	ChildSlot
+	[
+		SNew(SButton)
+		.ButtonStyle(FAppStyle::Get(), "SimpleButton")
+		.ContentPadding(FMargin(4.0f, 1.0f))
+		.ToolTipText(LOCTEXT("CopyMessageTooltip", "Copy this message to the clipboard"))
+		.OnClicked(this, &SCopyButton::OnCopyClicked)
+		[
+			SAssignNew(Label, STextBlock)
+			.Text(LOCTEXT("CopyMessage", "Copy"))
+			.TextStyle(FAppStyle::Get(), "SmallText")
+			.ColorAndOpacity(FSlateColor(FLinearColor(0.6f, 0.6f, 0.65f)))
+		]
+	];
+}
+
+FReply SCopyButton::OnCopyClicked()
+{
+	const FString TextToCopy = OnGetTextDelegate.IsBound() ? OnGetTextDelegate.Execute() : FString();
+	FPlatformApplicationMisc::ClipboardCopy(*TextToCopy);
+
+	if (Label.IsValid())
+	{
+		Label->SetText(LOCTEXT("CopiedMessage", "Copied!"));
+	}
+
+	// Show the "Copied!" feedback for a short window. Re-clicking extends the deadline
+	// rather than stacking timers.
+	FeedbackDeadline = FSlateApplication::Get().GetCurrentTime() + 1.5;
+	if (!bShowingFeedback)
+	{
+		bShowingFeedback = true;
+		RegisterActiveTimer(0.25f, FWidgetActiveTimerDelegate::CreateSP(this, &SCopyButton::TickFeedback));
+	}
+
+	return FReply::Handled();
+}
+
+EActiveTimerReturnType SCopyButton::TickFeedback(double InCurrentTime, float InDeltaTime)
+{
+	if (InCurrentTime < FeedbackDeadline)
+	{
+		return EActiveTimerReturnType::Continue;
+	}
+
+	if (Label.IsValid())
+	{
+		Label->SetText(LOCTEXT("CopyMessage", "Copy"));
+	}
+	bShowingFeedback = false;
+	return EActiveTimerReturnType::Stop;
 }
 
 // ============================================================================
@@ -779,16 +857,36 @@ void SClaudeEditorWidget::StartStreamingResponse()
 		// First text segment is wrapped in its own container so it can be swapped for Markdown / code blocks on finalize
 		TSharedPtr<SVerticalBox> FirstSegmentContainer;
 
+		// Per-bubble copy text: the button reads this ref so it always copies this
+		// response, even after later requests overwrite the streaming members.
+		StreamingCopyTextRef = MakeShared<FString>();
+		TSharedPtr<FString> CopyTextRef = StreamingCopyTextRef;
+
 		SAssignNew(StreamingContentBox, SVerticalBox)
 
 		+ SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(0, 0, 0, 6)
 		[
-			SNew(STextBlock)
-			.Text(FText::FromString(TEXT("Claude")))
-			.TextStyle(FAppStyle::Get(), "SmallText")
-			.ColorAndOpacity(FSlateColor(FLinearColor(0.9f, 0.6f, 0.3f)))
+			SNew(SHorizontalBox)
+
+			+ SHorizontalBox::Slot()
+			.FillWidth(1.0f)
+			.VAlign(VAlign_Center)
+			[
+				SNew(STextBlock)
+				.Text(FText::FromString(TEXT("Claude")))
+				.TextStyle(FAppStyle::Get(), "SmallText")
+				.ColorAndOpacity(FSlateColor(FLinearColor(0.9f, 0.6f, 0.3f)))
+			]
+
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			[
+				SNew(SCopyButton)
+				.OnGetText_Lambda([CopyTextRef]() { return CopyTextRef.IsValid() ? *CopyTextRef : FString(); })
+			]
 		]
 
 		+ SVerticalBox::Slot()
@@ -920,6 +1018,13 @@ void SClaudeEditorWidget::FinalizeStreamingResponse()
 		StreamingResponse = Rebuilt;
 		LastResponse = StreamingResponse;
 	}
+
+	// Freeze this bubble's copy text so its copy button keeps copying this response
+	if (StreamingCopyTextRef.IsValid())
+	{
+		*StreamingCopyTextRef = StreamingResponse.IsEmpty() ? CurrentSegmentText : StreamingResponse;
+	}
+	StreamingCopyTextRef.Reset();
 
 	// Render each segment in its own container so text appears before/after tool blocks in the right order
 	for (int32 i = 0; i < TextSegmentContainers.Num() && i < AllTextSegments.Num(); ++i)

--- a/UnrealClaude/Source/UnrealClaude/Public/ClaudeEditorWidget.h
+++ b/UnrealClaude/Source/UnrealClaude/Public/ClaudeEditorWidget.h
@@ -13,6 +13,7 @@ class SVerticalBox;
 class SClaudeInputArea;
 class SExpandableArea;
 class SMarkdownWidget;
+class STextBlock;
 
 /**
  * Helper widget that wraps a scroll box and provides right-click drag scrolling
@@ -39,6 +40,35 @@ private:
 	bool bIsDragging = false;
 	FVector2D DragStartMousePos;
 	float DragStartScrollOffset = 0.0f;
+};
+
+/** Returns the text that a copy button should place on the clipboard (evaluated at click time) */
+DECLARE_DELEGATE_RetVal(FString, FOnGetCopyText)
+
+/**
+ * Small "Copy" button that copies a caller-provided string to the clipboard and
+ * briefly shows "Copied!" feedback. The text is resolved lazily via OnGetText so it
+ * works for content that is still streaming when the button is created.
+ */
+class SCopyButton : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SCopyButton)
+	{}
+		/** Called on click to obtain the text to copy */
+		SLATE_EVENT(FOnGetCopyText, OnGetText)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	FReply OnCopyClicked();
+	EActiveTimerReturnType TickFeedback(double InCurrentTime, float InDeltaTime);
+
+	FOnGetCopyText OnGetTextDelegate;
+	TSharedPtr<STextBlock> Label;
+	bool bShowingFeedback = false;
+	double FeedbackDeadline = 0.0;
 };
 
 /**
@@ -157,6 +187,11 @@ private:
 
 	/** Accumulated streaming response */
 	FString StreamingResponse;
+
+	/** Per-bubble copy text for the current streaming response, filled in on finalize.
+	 *  Held by shared ref so the streaming bubble's copy button keeps copying its own
+	 *  text even after later requests overwrite StreamingResponse/LastResponse. */
+	TSharedPtr<FString> StreamingCopyTextRef;
 
 	/** Current streaming message widget (for updating in place) */
 	TSharedPtr<STextBlock> StreamingTextBlock;


### PR DESCRIPTION
This pull request adds a new "Copy" button to each chat message and streaming response in the `ClaudeEditorWidget`, allowing users to easily copy message text to the clipboard. The button provides immediate feedback by temporarily displaying "Copied!" after being clicked, and is designed to work correctly even for messages that are still streaming.

**New copy button functionality:**

* Added the `SCopyButton` widget, which copies a caller-provided string to the clipboard and shows "Copied!" feedback. The text to copy is resolved at click time to support streaming content. (`UnrealClaude/Source/UnrealClaude/Public/ClaudeEditorWidget.h` [[1]](diffhunk://#diff-10c91264ce19dfb38e27b952f7a454e96a7919f2237e36f8f9df26315ed76d6aR45-R73) [[2]](diffhunk://#diff-10c91264ce19dfb38e27b952f7a454e96a7919f2237e36f8f9df26315ed76d6aR191-R195); `UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp` [[3]](diffhunk://#diff-2a2dc4a9df9770a974d40b2a073b4385f6cecb884720600d9ce5f3438ea2bb64R224-R284)
* Integrated the copy button into each chat message and streaming response bubble, ensuring users can copy any message, including those still being generated. (`UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp` [[1]](diffhunk://#diff-2a2dc4a9df9770a974d40b2a073b4385f6cecb884720600d9ce5f3438ea2bb64R191-R213) [[2]](diffhunk://#diff-2a2dc4a9df9770a974d40b2a073b4385f6cecb884720600d9ce5f3438ea2bb64R860-R891)

**Clipboard and feedback handling:**

* Implemented logic to ensure the copy button always copies the correct text, even after new messages arrive, by using a shared reference to the message content that is finalized when streaming completes. (`UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp` [[1]](diffhunk://#diff-2a2dc4a9df9770a974d40b2a073b4385f6cecb884720600d9ce5f3438ea2bb64R1022-R1028) [[2]](diffhunk://#diff-2a2dc4a9df9770a974d40b2a073b4385f6cecb884720600d9ce5f3438ea2bb64R860-R891); `UnrealClaude/Source/UnrealClaude/Public/ClaudeEditorWidget.h` [[3]](diffhunk://#diff-10c91264ce19dfb38e27b952f7a454e96a7919f2237e36f8f9df26315ed76d6aR191-R195)
* Added necessary includes for clipboard and application timing functionality. (`UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cpp` [UnrealClaude/Source/UnrealClaude/Private/ClaudeEditorWidget.cppR29](diffhunk://#diff-2a2dc4a9df9770a974d40b2a073b4385f6cecb884720600d9ce5f3438ea2bb64R29))
* Declared forward reference for `STextBlock` required by `SCopyButton`. (`UnrealClaude/Source/UnrealClaude/Public/ClaudeEditorWidget.h` [UnrealClaude/Source/UnrealClaude/Public/ClaudeEditorWidget.hR16](diffhunk://#diff-10c91264ce19dfb38e27b952f7a454e96a7919f2237e36f8f9df26315ed76d6aR16))

<img width="962" height="522" alt="Capture d&#39;écran 2026-06-17 113314" src="https://github.com/user-attachments/assets/3a3884d1-3047-440d-b6d0-632f5067df4d" />
