### PR TITLE
Fix UE 5.8 compile errors from FJsonObject key-type change

### DIFF
--- a/UnrealClaude/Source/UnrealClaude/Private/AnimationBlueprintUtils.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/AnimationBlueprintUtils.cpp
@@ -927,7 +927,7 @@ TSharedPtr<FJsonObject> FAnimationBlueprintUtils::ExecuteBatchOperations(
 				{
 					for (const auto& Pair : (*BindingsObj)->Values)
 					{
-						Bindings.Add(Pair.Key, Pair.Value->AsString());
+						Bindings.Add(FString(Pair.Key.ToView()), Pair.Value->AsString());
 					}
 				}
 				bOpSuccess = SetStateBlendSpace(

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/MCPToolBase.h
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/MCPToolBase.h
@@ -170,9 +170,10 @@ protected:
 		TArray<FString> Unknown;
 		for (const auto& Pair : Params->Values)
 		{
-			if (!Known.Contains(Pair.Key))
+			FString KeyStr(Pair.Key.ToView());
+			if (!Known.Contains(KeyStr))
 			{
-				Unknown.Add(Pair.Key);
+				Unknown.Add(MoveTemp(KeyStr));
 			}
 		}
 		return Unknown;

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_AnimBlueprintModify.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_AnimBlueprintModify.cpp
@@ -775,7 +775,7 @@ FMCPToolResult FMCPTool_AnimBlueprintModify::HandleSetStateAnimation(const FStri
 		{
 			for (const auto& Pair : (*BindingsObj)->Values)
 			{
-				Bindings.Add(Pair.Key, Pair.Value->AsString());
+				Bindings.Add(FString(Pair.Key.ToView()), Pair.Value->AsString());
 			}
 		}
 		bSuccess = FAnimationBlueprintUtils::SetStateBlendSpace(

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_BlueprintModify.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_BlueprintModify.cpp
@@ -398,7 +398,7 @@ FMCPToolResult FMCPTool_BlueprintModify::ExecuteAddNode(const TSharedRef<FJsonOb
 				if (PinValue.Value->TryGetString(PinValueStr))
 				{
 					FString PinError;
-					FBlueprintUtils::SetPinDefaultValue(Graph, NodeId, PinValue.Key, PinValueStr, PinError);
+					FBlueprintUtils::SetPinDefaultValue(Graph, NodeId, FString(PinValue.Key.ToView()), PinValueStr, PinError);
 				}
 			}
 		}
@@ -545,7 +545,7 @@ bool FMCPTool_BlueprintModify::CreateNodesFromSpec(
 				if (PinValue.Value->TryGetString(PinValueStr))
 				{
 					FString PinError;
-					FBlueprintUtils::SetPinDefaultValue(Graph, NodeId, PinValue.Key, PinValueStr, PinError);
+					FBlueprintUtils::SetPinDefaultValue(Graph, NodeId, FString(PinValue.Key.ToView()), PinValueStr, PinError);
 				}
 			}
 		}

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_Material.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_Material.cpp
@@ -541,7 +541,7 @@ bool FMCPTool_Material::ApplyParametersFromJson(UMaterialInstanceConstant* MatIn
 			if (Pair.Value->TryGetNumber(Value))
 			{
 				FString Error;
-				if (!SetScalarParameter(MatInst, Pair.Key, static_cast<float>(Value), Error))
+				if (!SetScalarParameter(MatInst, FString(Pair.Key.ToView()), static_cast<float>(Value), Error))
 				{
 					Errors.Add(Error);
 					bAllSuccess = false;
@@ -566,7 +566,7 @@ bool FMCPTool_Material::ApplyParametersFromJson(UMaterialInstanceConstant* MatIn
 				(*ColorObj)->TryGetNumberField(TEXT("a"), Color.A);
 
 				FString Error;
-				if (!SetVectorParameter(MatInst, Pair.Key, Color, Error))
+				if (!SetVectorParameter(MatInst, FString(Pair.Key.ToView()), Color, Error))
 				{
 					Errors.Add(Error);
 					bAllSuccess = false;
@@ -584,7 +584,7 @@ bool FMCPTool_Material::ApplyParametersFromJson(UMaterialInstanceConstant* MatIn
 			if (Pair.Value->TryGetString(TexturePath))
 			{
 				FString Error;
-				if (!SetTextureParameter(MatInst, Pair.Key, TexturePath, Error))
+				if (!SetTextureParameter(MatInst, FString(Pair.Key.ToView()), TexturePath, Error))
 				{
 					Errors.Add(Error);
 					bAllSuccess = false;

--- a/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_SetProperty.cpp
+++ b/UnrealClaude/Source/UnrealClaude/Private/MCP/Tools/MCPTool_SetProperty.cpp
@@ -376,7 +376,7 @@ bool FMCPTool_SetProperty::SetStructPropertyValue(FStructProperty* StructProp, v
 		for (const auto& Pair : (*ObjVal)->Values)
 		{
 			if (!bFirst) TextRepresentation += TEXT(",");
-			TextRepresentation += Pair.Key.ToUpper() + TEXT("=");
+			TextRepresentation += FString(Pair.Key.ToView()).ToUpper() + TEXT("=");
 
 			double NumVal;
 			FString StrVal;

--- a/UnrealClaude/UnrealClaude.uplugin
+++ b/UnrealClaude/UnrealClaude.uplugin
@@ -3,7 +3,7 @@
 	"Version": 13,
 	"VersionName": "1.5.1",
 	"FriendlyName": "Unreal Claude",
-	"Description": "Claude Code CLI integration for Unreal Engine 5.7. Get AI coding assistance with built-in UE5.7 documentation context directly in the editor.",
+	"Description": "Claude Code CLI integration for Unreal Engine 5.8. Get AI coding assistance with built-in UE5.8 documentation context directly in the editor.",
 	"Category": "Editor",
 	"CreatedBy": "Natali Caggiano",
 	"CreatedByURL": "https://github.com/Natfii",
@@ -15,7 +15,7 @@
 	"IsExperimentalVersion": false,
 	"Installed": false,
 	"EnabledByDefault": true,
-	"EngineVersion": "5.7.0",
+	"EngineVersion": "5.8.0",
 	"SupportedTargetPlatforms": [ "Win64", "Linux", "Mac" ],
 	"Modules": [
 		{


### PR DESCRIPTION
## Summary
- UE 5.8 changed `FJsonObject::Values`'s map key type from `FString` to `UE::FSharedString`, which broke every call site that passed `Pair.Key` directly into APIs expecting an `FString` (`TSet<FString>::Contains`, `TArray<FString>::Add`, `TMap<FString,...>::Add`, and a few tool-specific setter functions).
- Fixes each site by converting the key with `FString(Key.ToView())` before use.
- Replaces an `FSharedString::ToUpper()` call (no longer exists on that type) with `FString(Key.ToView()).ToUpper()`.
- Bumps `UnrealClaude.uplugin` `EngineVersion` to `5.8.0` (and updates the description string) since the plugin now targets 5.8.

## Verification
Built clean end-to-end via:
```
RunUAT.bat BuildPlugin -Plugin=UnrealClaude/UnrealClaude.uplugin -Package=<out> -TargetPlatforms=Win64
```
against a UE 5.8.0 engine install. All 73 compile units succeeded, plugin DLL linked without errors.

## Test plan
- [x] `BuildPlugin` via RunUAT against UE 5.8 completes with `BUILD SUCCESSFUL`
- [ ] Maintainer smoke-test in-editor on 5.8 (chat panel, MCP tools touching JSON params: blueprint modify, material params, anim blueprint modify, set_property)